### PR TITLE
fix: Don't use m2-settings.xml in release-please

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -54,7 +54,6 @@ jobs:
       - name: Deploy with Maven
         run: |
           mvn --batch-mode \
-          --settings release/m2-settings.xml \
           clean deploy
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}


### PR DESCRIPTION
Managed to reproduce the error `gpg: signing failed: No pinentry` in this Draft PR's commit: https://github.com/spotify/confidence-openfeature-provider-java/pull/12/commits/196d9c6f40c37d02da60c1664dec7ae68b5e76f1

The problem seems to be usage of the settings file `release/m2-settings.xml`: I think this might trigger the password prompt when executing `mvn deploy`, rather than using the GPG password that we have set in `setup-java`