### PR TITLE
ci: Fix deploy signing

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -58,3 +58,4 @@ jobs:
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          GPG_PASS: ${{ secrets.SIGN_KEY_PASS }} # Password chosen when creating the GPG key

--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,11 @@
           <gpgArguments>
             <arg>--pinentry-mode</arg>
             <arg>loopback</arg>
+            <arg>--no-tty</arg>
           </gpgArguments>
+          <passphrase>
+            ${env.GPG_PASS}
+          </passphrase>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
So we pass the passphrase via an environment variable directly to the maven plugin in the pom-file. Not the most elegant solution but I think it should work.