### PR TITLE
fix: Update ossrh release repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </snapshotRepository>
     <repository>
       <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      <url>https://oss.sonatype.org/content/repositories/releases/</url>
     </repository>
   </distributionManagement>
 


### PR DESCRIPTION
Latest [release PR](https://github.com/spotify/confidence-openfeature-provider-java/pull/33) triggered the following steps in CI:
```
[INFO] Uploading to ossrh: https://oss.sonatype.org/service/local/staging/deploy/maven2/com/spotify/confidence-openfeature-provider/0.0.1/confidence-openfeature-provider-0.0.1.jar
[INFO] Uploaded to ossrh: https://oss.sonatype.org/service/local/staging/deploy/maven2/com/spotify/confidence-openfeature-provider/0.0.1/confidence-openfeature-provider-0.0.1.jar (381 kB at 47 kB/s)
[INFO] Uploading to ossrh: https://oss.sonatype.org/service/local/staging/deploy/maven2/com/spotify/confidence-openfeature-provider/0.0.1/confidence-openfeature-provider-0.0.1.pom
[INFO] Uploaded to ossrh: https://oss.sonatype.org/service/local/staging/deploy/maven2/com/spotify/confidence-openfeature-provider/0.0.1/confidence-openfeature-provider-0.0.1.pom (10 kB at 60 kB/s)
[INFO] Downloading from ossrh: https://oss.sonatype.org/service/local/staging/deploy/maven2/com/spotify/confidence-openfeature-provider/maven-metadata.xml
[INFO] Uploading to ossrh: https://oss.sonatype.org/service/local/staging/deploy/maven2/com/spotify/confidence-openfeature-provider/maven-metadata.xml
[INFO] Uploaded to ossrh: https://oss.sonatype.org/service/local/staging/deploy/maven2/com/spotify/confidence-openfeature-provider/maven-metadata.xml (322 B at 1.9 kB/s)
```

The upload was successful, but the artefact is not discoverable in the ["releases" repository](https://repo1.maven.org/maven2/) (also reachable [here](https://oss.sonatype.org/#view-repositories;releases~browsestorage)). It's possible it just takes some time for the artifact to be discoverable (but this is unlikely to be the problem, since I checked more than one hour after the upload).

If the problem persists, this PR suggests a way to upload directly to "releases", bypassing "staging". Note that this change is not backed by the official [documentation](https://central.sonatype.org/publish/publish-maven/#review-requirements), that rather indicates to use the `distributionManagement` we currently have in `main`.

In [another WIP branch](https://github.com/spotify/confidence-openfeature-provider-java/compare/nexus?expand=1), we are experimenting using the official `nexus-staging-maven-plugin` for deployments, if this problem persists in the current setup. 