### PR TITLE
ci: sign during install phase

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -265,7 +265,7 @@
         <executions>
           <execution>
             <id>sign-artifacts</id>
-            <phase>verify</phase>
+            <phase>install</phase>
             <goals>
               <goal>sign</goal>
             </goals>


### PR DESCRIPTION
This will move the signing to happen during the Maven `install` phase which will make sure that the uploads to sonatype will contain the signed artifacts.