### PR TITLE
fix: attach sources to deployment

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -249,6 +249,14 @@
       <plugin>
         <artifactId>maven-source-plugin</artifactId>
         <version>3.3.0</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar-no-fork</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This should make sure that we are also uploading sources during the deploy phase.