### PR TITLE
refactor: Add ConfidenceWrapper for OF Metadata injection

### DIFF
--- a/openfeature-provider/pom.xml
+++ b/openfeature-provider/pom.xml
@@ -10,11 +10,13 @@
   <artifactId>openfeature-provider</artifactId>
 
   <dependencies>
+    <!-- x-release-please-start-version -->
     <dependency>
       <groupId>com.spotify.confidence</groupId>
       <artifactId>sdk-java</artifactId>
-      <version>0.0.16-SNAPSHOT</version>
+      <version>0.1.0</version>
     </dependency>
+    <!---x-release-please-end-->
     <dependency>
       <groupId>dev.openfeature</groupId>
       <artifactId>sdk</artifactId>

--- a/openfeature-provider/src/main/java/com/spotify/confidence/ConfidenceFeatureProvider.java
+++ b/openfeature-provider/src/main/java/com/spotify/confidence/ConfidenceFeatureProvider.java
@@ -15,8 +15,6 @@ import dev.openfeature.sdk.Value;
 import dev.openfeature.sdk.exceptions.FlagNotFoundError;
 import dev.openfeature.sdk.exceptions.GeneralError;
 import dev.openfeature.sdk.exceptions.TypeMismatchError;
-import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.grpc.Status.Code;
 import io.grpc.StatusRuntimeException;
 import java.util.Map;
@@ -32,58 +30,26 @@ public class ConfidenceFeatureProvider implements FeatureProvider {
   /**
    * ConfidenceFeatureProvider constructor
    *
-   * @param confidence an instance of the Confidence
+   * @param confidenceWrapper obtained via {@link #createConfidenceWrapper(Confidence.Builder)}
    */
-  public ConfidenceFeatureProvider(Confidence confidence) {
-    this.confidence = confidence;
+  public ConfidenceFeatureProvider(ConfidenceWrapper confidenceWrapper) {
+    this.confidence = confidenceWrapper.confidence;
+  }
+
+  public ConfidenceWrapper createConfidenceWrapper(Confidence.Builder confidenceBuilder) {
+    return new ConfidenceWrapper(confidenceBuilder.metadata("SDK_ID_JAVA_PROVIDER").build());
   }
 
   private static final Logger log =
       org.slf4j.LoggerFactory.getLogger(ConfidenceFeatureProvider.class);
 
-  /**
-   * ConfidenceFeatureProvider constructor
-   *
-   * @param clientSecret generated from the Confidence portal
-   * @param managedChannel gRPC channel
-   * @deprecated This constructor is deprecated. Please use {@link
-   *     #ConfidenceFeatureProvider(Confidence)} instead.
-   */
-  @Deprecated()
-  public ConfidenceFeatureProvider(String clientSecret, ManagedChannel managedChannel) {
-    this(Confidence.builder(clientSecret).flagResolverManagedChannel(managedChannel).build());
-  }
-
-  /**
-   * ConfidenceFeatureProvider constructor
-   *
-   * @param clientSecret generated from the Confidence portal
-   * @deprecated This constructor is deprecated. Please use {@link
-   *     #ConfidenceFeatureProvider(Confidence)} instead.
-   */
-  @Deprecated()
-  public ConfidenceFeatureProvider(String clientSecret) {
-    this(clientSecret, ManagedChannelBuilder.forAddress("edge-grpc.spotify.com", 443).build());
-  }
-
-  /**
-   * ConfidenceFeatureProvider constructor that allows you to override the default gRPC host and
-   * port, used for local resolver.
-   *
-   * @param clientSecret generated from the Confidence portal
-   * @param host gRPC host you want to connect to.
-   * @param port port of the gRPC host that you want to use.
-   * @deprecated This constructor is deprecated. Please use {@link
-   *     #ConfidenceFeatureProvider(Confidence)} instead.
-   */
-  @Deprecated()
-  public ConfidenceFeatureProvider(String clientSecret, String host, int port) {
-    this(clientSecret, ManagedChannelBuilder.forAddress(host, port).usePlaintext().build());
+  protected ConfidenceFeatureProvider(Confidence confidence) {
+    this.confidence = confidence;
   }
 
   @Override
   public Metadata getMetadata() {
-    return () -> "com.spotify.confidence.flags.resolver.v1.FlagResolverService";
+    return () -> "ConfidenceProvider";
   }
 
   @Override
@@ -163,7 +129,7 @@ public class ConfidenceFeatureProvider implements FeatureProvider {
                   Map.of(
                       OPEN_FEATURE_RESOLVE_CONTEXT_KEY,
                       ConfidenceValue.Struct.fromProto(evaluationContext)))
-              .resolveFlags(requestFlagName, true)
+              .resolveFlags(requestFlagName)
               .get();
 
       if (resolveFlagResponse.getResolvedFlagsList().isEmpty()) {
@@ -243,6 +209,14 @@ public class ConfidenceFeatureProvider implements FeatureProvider {
           String.format(
               "Unknown error occurred when calling the provider backend. Exception: %s",
               e.getMessage()));
+    }
+  }
+
+  public static class ConfidenceWrapper {
+    public final Confidence confidence;
+
+    private ConfidenceWrapper(Confidence confidence) {
+      this.confidence = confidence;
     }
   }
 }

--- a/openfeature-provider/src/test/java/com/spotify/confidence/FeatureProviderTest.java
+++ b/openfeature-provider/src/test/java/com/spotify/confidence/FeatureProviderTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.mock;
 
 import com.google.protobuf.util.Structs;
 import com.google.protobuf.util.Values;
+import com.spotify.confidence.Confidence.ConfidenceMetadata;
 import com.spotify.confidence.ResolverClientTestUtils.ValueSchemaHolder;
 import com.spotify.confidence.shaded.flags.resolver.v1.FlagResolverServiceGrpc.FlagResolverServiceImplBase;
 import com.spotify.confidence.shaded.flags.resolver.v1.ResolveFlagsRequest;
@@ -70,7 +71,8 @@ final class FeatureProviderTest {
     final FakeEventSenderEngine fakeEventSender = new FakeEventSenderEngine(new FakeClock());
     channel = InProcessChannelBuilder.forName(serverName).directExecutor().build();
     final FlagResolverClientImpl flagResolver =
-        new FlagResolverClientImpl(new GrpcFlagResolver("fake-secret", channel));
+        new FlagResolverClientImpl(
+            new GrpcFlagResolver("fake-secret", channel, new ConfidenceMetadata("")));
     final Confidence confidence = Confidence.create(fakeEventSender, flagResolver);
     final FeatureProvider featureProvider = new ConfidenceFeatureProvider(confidence);
 

--- a/openfeature-provider/src/test/java/com/spotify/confidence/FlagResolverContextTest.java
+++ b/openfeature-provider/src/test/java/com/spotify/confidence/FlagResolverContextTest.java
@@ -49,8 +49,7 @@ class FakeFlagResolver implements FlagResolver {
   public void close() {}
 
   @Override
-  public CompletableFuture<ResolveFlagsResponse> resolve(
-      String flag, Struct context, Boolean isProvider) {
+  public CompletableFuture<ResolveFlagsResponse> resolve(String flag, Struct context) {
     this.context = context;
     return null;
   }

--- a/openfeature-provider/src/test/java/com/spotify/confidence/ResolverClientTestUtils.java
+++ b/openfeature-provider/src/test/java/com/spotify/confidence/ResolverClientTestUtils.java
@@ -24,7 +24,7 @@ public class ResolverClientTestUtils {
 
     @Override
     public CompletableFuture<ResolveFlagsResponse> resolveFlags(
-        String flag, ConfidenceValue.Struct context, Boolean isProvider) {
+        String flag, ConfidenceValue.Struct context) {
       resolves.put(flag, context);
       return CompletableFuture.completedFuture(response);
     }

--- a/sdk-java/src/main/java/com/spotify/confidence/EventSenderEngineImpl.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/EventSenderEngineImpl.java
@@ -1,6 +1,7 @@
 package com.spotify.confidence;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.spotify.confidence.Confidence.ConfidenceMetadata;
 import com.spotify.confidence.events.v1.Event;
 import dev.failsafe.Failsafe;
 import dev.failsafe.FailsafeExecutor;
@@ -17,7 +18,6 @@ import java.util.concurrent.locks.LockSupport;
 import org.slf4j.Logger;
 
 class EventSenderEngineImpl implements EventSenderEngine {
-
   static final String EVENT_NAME_PREFIX = "eventDefinitions/";
   static final int DEFAULT_BATCH_SIZE = 25;
   static final Duration DEFAULT_MAX_FLUSH_INTERVAL = Duration.ofSeconds(60);
@@ -64,10 +64,11 @@ class EventSenderEngineImpl implements EventSenderEngine {
     pollingThread.start();
   }
 
-  EventSenderEngineImpl(String clientSecret, ManagedChannel channel, Clock clock) {
+  EventSenderEngineImpl(
+      String clientSecret, ManagedChannel channel, Clock clock, ConfidenceMetadata metadata) {
     this(
         DEFAULT_BATCH_SIZE,
-        new GrpcEventUploader(clientSecret, clock, channel),
+        new GrpcEventUploader(clientSecret, clock, channel, metadata),
         clock,
         DEFAULT_MAX_FLUSH_INTERVAL,
         DEFAULT_MAX_MEMORY_CONSUMPTION);

--- a/sdk-java/src/main/java/com/spotify/confidence/FlagResolver.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/FlagResolver.java
@@ -7,6 +7,5 @@ import java.util.concurrent.CompletableFuture;
 interface FlagResolver {
   void close();
 
-  public CompletableFuture<ResolveFlagsResponse> resolve(
-      String flag, Struct context, Boolean isProvider);
+  public CompletableFuture<ResolveFlagsResponse> resolve(String flag, Struct context);
 }

--- a/sdk-java/src/main/java/com/spotify/confidence/FlagResolverClient.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/FlagResolverClient.java
@@ -5,6 +5,5 @@ import java.io.Closeable;
 import java.util.concurrent.CompletableFuture;
 
 interface FlagResolverClient extends Closeable {
-  CompletableFuture<ResolveFlagsResponse> resolveFlags(
-      String flag, ConfidenceValue.Struct context, Boolean isProvider);
+  CompletableFuture<ResolveFlagsResponse> resolveFlags(String flag, ConfidenceValue.Struct context);
 }

--- a/sdk-java/src/main/java/com/spotify/confidence/FlagResolverClientImpl.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/FlagResolverClientImpl.java
@@ -14,7 +14,7 @@ class FlagResolverClientImpl implements FlagResolverClient {
   }
 
   public CompletableFuture<ResolveFlagsResponse> resolveFlags(
-      String flagName, ConfidenceValue.Struct context, Boolean isProvider) {
+      String flagName, ConfidenceValue.Struct context) {
     final Struct.Builder evaluationContextBuilder = context.toProto().getStructValue().toBuilder();
     if (context.asMap().containsKey(OPEN_FEATURE_RESOLVE_CONTEXT_KEY)) {
       final Value openFeatureEvaluationContext =
@@ -25,7 +25,7 @@ class FlagResolverClientImpl implements FlagResolverClient {
       evaluationContextBuilder.removeFields(OPEN_FEATURE_RESOLVE_CONTEXT_KEY);
     }
 
-    return this.grpcFlagResolver.resolve(flagName, evaluationContextBuilder.build(), isProvider);
+    return this.grpcFlagResolver.resolve(flagName, evaluationContextBuilder.build());
   }
 
   @Override

--- a/sdk-java/src/main/java/com/spotify/confidence/GrpcFlagResolver.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/GrpcFlagResolver.java
@@ -2,6 +2,7 @@ package com.spotify.confidence;
 
 import com.google.common.base.Strings;
 import com.google.protobuf.Struct;
+import com.spotify.confidence.Confidence.ConfidenceMetadata;
 import com.spotify.confidence.shaded.flags.resolver.v1.*;
 import com.spotify.confidence.shaded.flags.resolver.v1.Sdk.Builder;
 import io.grpc.ManagedChannel;
@@ -13,20 +14,22 @@ public class GrpcFlagResolver implements FlagResolver {
   private final ManagedChannel managedChannel;
   private final String clientSecret;
   private final Builder sdkBuilder = Sdk.newBuilder().setVersion(ConfidenceUtils.getSdkVersion());
+  private final ConfidenceMetadata metadata;
 
   private final FlagResolverServiceGrpc.FlagResolverServiceFutureStub stub;
 
-  public GrpcFlagResolver(String clientSecret, ManagedChannel managedChannel) {
+  public GrpcFlagResolver(
+      String clientSecret, ManagedChannel managedChannel, ConfidenceMetadata metadata) {
     if (Strings.isNullOrEmpty(clientSecret)) {
       throw new IllegalArgumentException("clientSecret must be a non-empty string.");
     }
     this.clientSecret = clientSecret;
     this.managedChannel = managedChannel;
+    this.metadata = metadata;
     this.stub = FlagResolverServiceGrpc.newFutureStub(managedChannel);
   }
 
-  public CompletableFuture<ResolveFlagsResponse> resolve(
-      String flag, Struct context, Boolean isProvider) {
+  public CompletableFuture<ResolveFlagsResponse> resolve(String flag, Struct context) {
     return GrpcUtil.toCompletableFuture(
         stub.withDeadlineAfter(10, TimeUnit.SECONDS)
             .resolveFlags(
@@ -34,15 +37,18 @@ public class GrpcFlagResolver implements FlagResolver {
                     .setClientSecret(this.clientSecret)
                     .addAllFlags(List.of(flag))
                     .setEvaluationContext(context)
-                    .setSdk(
-                        sdkBuilder
-                            .setId(
-                                isProvider
-                                    ? SdkId.SDK_ID_JAVA_PROVIDER
-                                    : SdkId.SDK_ID_JAVA_CONFIDENCE)
-                            .build())
+                    .setSdk(getSdkId(metadata))
                     .setApply(true)
                     .build()));
+  }
+
+  private Sdk getSdkId(ConfidenceMetadata metadata) {
+    try {
+      sdkBuilder.setId(SdkId.valueOf(metadata.sdkId));
+    } catch (IllegalArgumentException e) {
+      sdkBuilder.setCustomId(metadata.sdkId);
+    }
+    return sdkBuilder.build();
   }
 
   public void close() {

--- a/sdk-java/src/test/java/com/spotify/confidence/ConfidenceResourceManagementTest.java
+++ b/sdk-java/src/test/java/com/spotify/confidence/ConfidenceResourceManagementTest.java
@@ -25,7 +25,7 @@ public class ConfidenceResourceManagementTest {
   public void testCloseChildShouldThrowFromResolveFlags() throws IOException {
     final Confidence child = root.withContext(Map.of("child-key", ConfidenceValue.of("child")));
     child.close();
-    assertThrows(IllegalStateException.class, () -> child.resolveFlags("test", false).get());
+    assertThrows(IllegalStateException.class, () -> child.resolveFlags("test").get());
   }
 
   @Test
@@ -48,7 +48,7 @@ public class ConfidenceResourceManagementTest {
       throws IOException, ExecutionException, InterruptedException {
     final Confidence child = root.withContext(Map.of("child-key", ConfidenceValue.of("child")));
     child.close();
-    root.resolveFlags("test", false).get();
+    root.resolveFlags("test").get();
     root.track("test", ConfidenceValue.of(Map.of("messageKey", ConfidenceValue.of("parent"))));
   }
 
@@ -56,8 +56,8 @@ public class ConfidenceResourceManagementTest {
   public void testCloseParentShouldAffectChild() throws IOException {
     final Confidence child = root.withContext(Map.of("child-key", ConfidenceValue.of("child")));
     root.close();
-    assertThrows(IllegalStateException.class, () -> child.resolveFlags("test", false).get());
-    assertThrows(IllegalStateException.class, () -> root.resolveFlags("test", false).get());
+    assertThrows(IllegalStateException.class, () -> child.resolveFlags("test").get());
+    assertThrows(IllegalStateException.class, () -> root.resolveFlags("test").get());
     assertTrue(fakeEngine.closed);
     assertTrue(fakeFlagResolverClient.closed);
   }

--- a/sdk-java/src/test/java/com/spotify/confidence/ConfidenceTest.java
+++ b/sdk-java/src/test/java/com/spotify/confidence/ConfidenceTest.java
@@ -261,8 +261,7 @@ final class ConfidenceTest {
   public static class FailingFlagResolverClient implements FlagResolverClient {
 
     @Override
-    public CompletableFuture<ResolveFlagsResponse> resolveFlags(
-        String flag, Struct context, Boolean isProvider) {
+    public CompletableFuture<ResolveFlagsResponse> resolveFlags(String flag, Struct context) {
       throw new RuntimeException("Crashing while performing network call");
     }
 

--- a/sdk-java/src/test/java/com/spotify/confidence/GrpcEventUploaderTest.java
+++ b/sdk-java/src/test/java/com/spotify/confidence/GrpcEventUploaderTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.Timestamp;
+import com.spotify.confidence.Confidence.ConfidenceMetadata;
 import com.spotify.confidence.events.v1.EventError;
 import com.spotify.confidence.events.v1.EventError.Reason;
 import com.spotify.confidence.events.v1.EventsServiceGrpc;
@@ -54,7 +55,8 @@ class GrpcEventUploaderTest {
     fakeClock.setCurrentTimeSeconds(1337);
 
     // Create a client that uses the channel
-    uploader = new GrpcEventUploader("my-client-secret", fakeClock, channel);
+    uploader =
+        new GrpcEventUploader("my-client-secret", fakeClock, channel, new ConfidenceMetadata(""));
   }
 
   @AfterEach

--- a/sdk-java/src/test/java/com/spotify/confidence/ResolverClientTestUtils.java
+++ b/sdk-java/src/test/java/com/spotify/confidence/ResolverClientTestUtils.java
@@ -24,7 +24,7 @@ public class ResolverClientTestUtils {
 
     @Override
     public CompletableFuture<ResolveFlagsResponse> resolveFlags(
-        String flag, ConfidenceValue.Struct context, Boolean isProvider) {
+        String flag, ConfidenceValue.Struct context) {
       resolves.put(flag, context);
       return CompletableFuture.completedFuture(response);
     }


### PR DESCRIPTION
Alternative and followup for #140. It partly reverts #140.

Cons of #140:
- `PROVIDER` ID only used for resolves, not for events (which were hardcoded to `CONFIDENCE`)
  - We had a soft-decision to have events be marked as PROVIDER (even if OF is not related to events at all), in case the user integration involves OF
- `isProvider` boolean was polluting the primary interfaces, and leaking to resolve APIs that are available to the final users

Cons of this PR:
- `ConfidenceMetadata` can always be overridden by users (it's part of the Confidence Builder!), although we would like to be in control of this at all times (this is also true in #140, with the `isBoolean` argument that can be used and set by users)
- `ConfidenceWrapper` is a new friction layer users need to deal with, but it should ensure only Confidence instances with the correctly overridden `PROVIDER` Metadata are passed into the Provider 
---
Also in this PR:
- Attempt to fix version in Provider's POM, seemingly broken after past release
- Remove some deprecated constructors