### PR TITLE
refactor: Add `ConfidenceInstance` and `FlagReaderForProvider` interfaces

### DIFF
--- a/openfeature-provider/pom.xml
+++ b/openfeature-provider/pom.xml
@@ -10,11 +10,13 @@
   <artifactId>openfeature-provider</artifactId>
 
   <dependencies>
+    <!-- x-release-please-start-version -->
     <dependency>
       <groupId>com.spotify.confidence</groupId>
       <artifactId>sdk-java</artifactId>
-      <version>0.0.16-SNAPSHOT</version>
+      <version>0.1.0</version>
     </dependency>
+    <!---x-release-please-end-->
     <dependency>
       <groupId>dev.openfeature</groupId>
       <artifactId>sdk</artifactId>

--- a/openfeature-provider/src/test/java/com/spotify/confidence/ConfidenceFeatureProviderTest.java
+++ b/openfeature-provider/src/test/java/com/spotify/confidence/ConfidenceFeatureProviderTest.java
@@ -1,6 +1,6 @@
 package com.spotify.confidence;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
 import dev.openfeature.sdk.ErrorCode;
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 class ConfidenceFeatureProviderTest {
 
-  private Confidence root;
+  private FlagReaderForProvider root;
   private FakeEventSenderEngine fakeEngine;
   private ResolverClientTestUtils.FakeFlagResolverClient fakeFlagResolverClient;
 
@@ -24,12 +24,13 @@ class ConfidenceFeatureProviderTest {
   public void setup() {
     fakeEngine = new FakeEventSenderEngine(new FakeClock());
     fakeFlagResolverClient = new ResolverClientTestUtils.FakeFlagResolverClient();
-    root = Confidence.create(fakeEngine, fakeFlagResolverClient);
+    root = Confidence.createForProvider(fakeEngine, fakeFlagResolverClient);
   }
 
   @Test
   public void testCloseChildShouldReturnDefaultsFromOpenFeatureApi() throws IOException {
-    final Confidence child = root.withContext(Map.of("child-key", ConfidenceValue.of("child")));
+    final FlagReaderForProvider child =
+        root.withContext(Map.of("child-key", ConfidenceValue.of("child")));
     OpenFeatureAPI.getInstance().setProvider(new ConfidenceFeatureProvider(child));
     child.close();
     final boolean defaultValue = false;

--- a/openfeature-provider/src/test/java/com/spotify/confidence/FeatureProviderTest.java
+++ b/openfeature-provider/src/test/java/com/spotify/confidence/FeatureProviderTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.mock;
 
 import com.google.protobuf.util.Structs;
 import com.google.protobuf.util.Values;
+import com.spotify.confidence.Confidence.ConfidenceMetadata;
 import com.spotify.confidence.ResolverClientTestUtils.ValueSchemaHolder;
 import com.spotify.confidence.shaded.flags.resolver.v1.FlagResolverServiceGrpc.FlagResolverServiceImplBase;
 import com.spotify.confidence.shaded.flags.resolver.v1.ResolveFlagsRequest;
@@ -70,8 +71,10 @@ final class FeatureProviderTest {
     final FakeEventSenderEngine fakeEventSender = new FakeEventSenderEngine(new FakeClock());
     channel = InProcessChannelBuilder.forName(serverName).directExecutor().build();
     final FlagResolverClientImpl flagResolver =
-        new FlagResolverClientImpl(new GrpcFlagResolver("fake-secret", channel));
-    final Confidence confidence = Confidence.create(fakeEventSender, flagResolver);
+        new FlagResolverClientImpl(
+            new GrpcFlagResolver("fake-secret", channel, new ConfidenceMetadata("")));
+    final FlagReaderForProvider confidence =
+        Confidence.createForProvider(fakeEventSender, flagResolver);
     final FeatureProvider featureProvider = new ConfidenceFeatureProvider(confidence);
 
     openFeatureAPI = OpenFeatureAPI.getInstance();

--- a/openfeature-provider/src/test/java/com/spotify/confidence/FlagResolverContextTest.java
+++ b/openfeature-provider/src/test/java/com/spotify/confidence/FlagResolverContextTest.java
@@ -13,14 +13,14 @@ import org.junit.jupiter.api.Test;
 public class FlagResolverContextTest {
   private FakeFlagResolver fakeFlagResolver;
   private Client client;
-  private Confidence confidence;
+  private FlagReaderForProvider confidence;
 
   @BeforeEach
   void beforeEach() {
     final FakeEventSenderEngine fakeEventSender = new FakeEventSenderEngine(new FakeClock());
     this.fakeFlagResolver = new FakeFlagResolver();
     final FlagResolverClientImpl flagResolver = new FlagResolverClientImpl(fakeFlagResolver);
-    this.confidence = Confidence.create(fakeEventSender, flagResolver);
+    this.confidence = Confidence.createForProvider(fakeEventSender, flagResolver);
     final FeatureProvider featureProvider = new ConfidenceFeatureProvider(confidence);
 
     final OpenFeatureAPI openFeatureAPI = OpenFeatureAPI.getInstance();
@@ -50,7 +50,7 @@ class FakeFlagResolver implements FlagResolver {
 
   @Override
   public CompletableFuture<ResolveFlagsResponse> resolve(
-      String flag, Struct context, Boolean isProvider) {
+      String flag, Struct context, String providerId) {
     this.context = context;
     return null;
   }

--- a/openfeature-provider/src/test/java/com/spotify/confidence/ResolverClientTestUtils.java
+++ b/openfeature-provider/src/test/java/com/spotify/confidence/ResolverClientTestUtils.java
@@ -24,7 +24,7 @@ public class ResolverClientTestUtils {
 
     @Override
     public CompletableFuture<ResolveFlagsResponse> resolveFlags(
-        String flag, ConfidenceValue.Struct context, Boolean isProvider) {
+        String flag, ConfidenceValue.Struct context, String providerId) {
       resolves.put(flag, context);
       return CompletableFuture.completedFuture(response);
     }

--- a/sdk-java/src/main/java/com/spotify/confidence/ConfidenceInstance.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/ConfidenceInstance.java
@@ -1,0 +1,3 @@
+package com.spotify.confidence;
+
+public interface ConfidenceInstance extends FlagReader, EventSender {}

--- a/sdk-java/src/main/java/com/spotify/confidence/EventSender.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/EventSender.java
@@ -1,10 +1,11 @@
 package com.spotify.confidence;
 
 import com.google.common.annotations.Beta;
+import java.io.Closeable;
 import java.util.Map;
 
 @Beta
-public interface EventSender extends Contextual {
+public interface EventSender extends Contextual, Closeable {
   public void track(String eventName, ConfidenceValue.Struct data);
 
   public void track(String eventName);

--- a/sdk-java/src/main/java/com/spotify/confidence/EventSenderEngineImpl.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/EventSenderEngineImpl.java
@@ -1,6 +1,7 @@
 package com.spotify.confidence;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.spotify.confidence.Confidence.ConfidenceMetadata;
 import com.spotify.confidence.events.v1.Event;
 import dev.failsafe.Failsafe;
 import dev.failsafe.FailsafeExecutor;
@@ -17,7 +18,6 @@ import java.util.concurrent.locks.LockSupport;
 import org.slf4j.Logger;
 
 class EventSenderEngineImpl implements EventSenderEngine {
-
   static final String EVENT_NAME_PREFIX = "eventDefinitions/";
   static final int DEFAULT_BATCH_SIZE = 25;
   static final Duration DEFAULT_MAX_FLUSH_INTERVAL = Duration.ofSeconds(60);
@@ -64,10 +64,11 @@ class EventSenderEngineImpl implements EventSenderEngine {
     pollingThread.start();
   }
 
-  EventSenderEngineImpl(String clientSecret, ManagedChannel channel, Clock clock) {
+  EventSenderEngineImpl(
+      String clientSecret, ManagedChannel channel, Clock clock, ConfidenceMetadata metadata) {
     this(
         DEFAULT_BATCH_SIZE,
-        new GrpcEventUploader(clientSecret, clock, channel),
+        new GrpcEventUploader(clientSecret, clock, channel, metadata),
         clock,
         DEFAULT_MAX_FLUSH_INTERVAL,
         DEFAULT_MAX_MEMORY_CONSUMPTION);

--- a/sdk-java/src/main/java/com/spotify/confidence/FlagReader.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/FlagReader.java
@@ -1,0 +1,10 @@
+package com.spotify.confidence;
+
+import java.io.Closeable;
+
+public interface FlagReader extends Closeable {
+
+  <T> T getValue(String key, T defaultValue);
+
+  <T> FlagEvaluation<T> getEvaluation(String key, T defaultValue);
+}

--- a/sdk-java/src/main/java/com/spotify/confidence/FlagReaderForProvider.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/FlagReaderForProvider.java
@@ -1,0 +1,16 @@
+package com.spotify.confidence;
+
+import com.spotify.confidence.shaded.flags.resolver.v1.ResolveFlagsResponse;
+import java.io.Closeable;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+
+public interface FlagReaderForProvider extends Contextual, Closeable {
+  CompletableFuture<ResolveFlagsResponse> resolveFlags(String flagName, String providerId);
+
+  FlagReaderForProvider withContext(ConfidenceValue.Struct context);
+
+  default FlagReaderForProvider withContext(Map<String, ConfidenceValue> context) {
+    return withContext(ConfidenceValue.Struct.of(context));
+  }
+}

--- a/sdk-java/src/main/java/com/spotify/confidence/FlagResolver.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/FlagResolver.java
@@ -8,5 +8,5 @@ interface FlagResolver {
   void close();
 
   public CompletableFuture<ResolveFlagsResponse> resolve(
-      String flag, Struct context, Boolean isProvider);
+      String flag, Struct context, String providerId);
 }

--- a/sdk-java/src/main/java/com/spotify/confidence/FlagResolverClient.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/FlagResolverClient.java
@@ -1,10 +1,15 @@
 package com.spotify.confidence;
 
+import com.spotify.confidence.ConfidenceValue.Struct;
 import com.spotify.confidence.shaded.flags.resolver.v1.ResolveFlagsResponse;
 import java.io.Closeable;
 import java.util.concurrent.CompletableFuture;
 
 interface FlagResolverClient extends Closeable {
   CompletableFuture<ResolveFlagsResponse> resolveFlags(
-      String flag, ConfidenceValue.Struct context, Boolean isProvider);
+      String flag, Struct context, String providerId);
+
+  default CompletableFuture<ResolveFlagsResponse> resolveFlags(String flag, String providerId) {
+    return resolveFlags(flag, ConfidenceValue.Struct.builder().build(), providerId);
+  }
 }

--- a/sdk-java/src/main/java/com/spotify/confidence/FlagResolverClientImpl.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/FlagResolverClientImpl.java
@@ -14,7 +14,7 @@ class FlagResolverClientImpl implements FlagResolverClient {
   }
 
   public CompletableFuture<ResolveFlagsResponse> resolveFlags(
-      String flagName, ConfidenceValue.Struct context, Boolean isProvider) {
+      String flagName, ConfidenceValue.Struct context, String providerId) {
     final Struct.Builder evaluationContextBuilder = context.toProto().getStructValue().toBuilder();
     if (context.asMap().containsKey(OPEN_FEATURE_RESOLVE_CONTEXT_KEY)) {
       final Value openFeatureEvaluationContext =
@@ -25,7 +25,7 @@ class FlagResolverClientImpl implements FlagResolverClient {
       evaluationContextBuilder.removeFields(OPEN_FEATURE_RESOLVE_CONTEXT_KEY);
     }
 
-    return this.grpcFlagResolver.resolve(flagName, evaluationContextBuilder.build(), isProvider);
+    return this.grpcFlagResolver.resolve(flagName, evaluationContextBuilder.build(), providerId);
   }
 
   @Override

--- a/sdk-java/src/main/java/com/spotify/confidence/GrpcEventUploader.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/GrpcEventUploader.java
@@ -1,6 +1,7 @@
 package com.spotify.confidence;
 
 import com.google.common.collect.ImmutableSet;
+import com.spotify.confidence.Confidence.ConfidenceMetadata;
 import com.spotify.confidence.events.v1.Event;
 import com.spotify.confidence.events.v1.EventsServiceGrpc;
 import com.spotify.confidence.events.v1.PublishEventsRequest;
@@ -16,7 +17,6 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 
 class GrpcEventUploader implements EventUploader {
-
   private final Set<Status.Code> RETRYABLE_STATUS_CODES =
       ImmutableSet.of(
           Status.Code.UNKNOWN,
@@ -26,24 +26,33 @@ class GrpcEventUploader implements EventUploader {
           Status.Code.ABORTED,
           Status.Code.INTERNAL,
           Status.Code.DATA_LOSS);
+  private final Sdk.Builder sdkBuilder =
+      Sdk.newBuilder().setVersion(ConfidenceUtils.getSdkVersion());
   private final String clientSecret;
   private final Sdk sdk;
-  private final ManagedChannel managedChannel;
   private final EventsServiceGrpc.EventsServiceFutureStub stub;
   private final Clock clock;
 
   private static final Logger log = org.slf4j.LoggerFactory.getLogger(GrpcEventUploader.class);
 
-  GrpcEventUploader(String clientSecret, Clock clock, ManagedChannel managedChannel) {
+  GrpcEventUploader(
+      String clientSecret,
+      Clock clock,
+      ManagedChannel managedChannel,
+      ConfidenceMetadata metadata) {
     this.clientSecret = clientSecret;
-    this.managedChannel = managedChannel;
     this.stub = EventsServiceGrpc.newFutureStub(managedChannel);
     this.clock = clock;
-    this.sdk =
-        Sdk.newBuilder()
-            .setId(SdkId.SDK_ID_JAVA_CONFIDENCE)
-            .setVersion(ConfidenceUtils.getSdkVersion())
-            .build();
+    this.sdk = getSdkId(metadata);
+  }
+
+  private Sdk getSdkId(ConfidenceMetadata metadata) {
+    try {
+      sdkBuilder.setId(SdkId.SDK_ID_JAVA_CONFIDENCE);
+    } catch (IllegalArgumentException e) {
+      sdkBuilder.setCustomId(metadata.sdkId);
+    }
+    return sdkBuilder.build();
   }
 
   @Override

--- a/sdk-java/src/main/java/com/spotify/confidence/GrpcFlagResolver.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/GrpcFlagResolver.java
@@ -2,6 +2,7 @@ package com.spotify.confidence;
 
 import com.google.common.base.Strings;
 import com.google.protobuf.Struct;
+import com.spotify.confidence.Confidence.ConfidenceMetadata;
 import com.spotify.confidence.shaded.flags.resolver.v1.*;
 import com.spotify.confidence.shaded.flags.resolver.v1.Sdk.Builder;
 import io.grpc.ManagedChannel;
@@ -13,20 +14,23 @@ public class GrpcFlagResolver implements FlagResolver {
   private final ManagedChannel managedChannel;
   private final String clientSecret;
   private final Builder sdkBuilder = Sdk.newBuilder().setVersion(ConfidenceUtils.getSdkVersion());
+  private final ConfidenceMetadata metadata;
 
   private final FlagResolverServiceGrpc.FlagResolverServiceFutureStub stub;
 
-  public GrpcFlagResolver(String clientSecret, ManagedChannel managedChannel) {
+  public GrpcFlagResolver(
+      String clientSecret, ManagedChannel managedChannel, ConfidenceMetadata metadata) {
     if (Strings.isNullOrEmpty(clientSecret)) {
       throw new IllegalArgumentException("clientSecret must be a non-empty string.");
     }
     this.clientSecret = clientSecret;
     this.managedChannel = managedChannel;
+    this.metadata = metadata;
     this.stub = FlagResolverServiceGrpc.newFutureStub(managedChannel);
   }
 
   public CompletableFuture<ResolveFlagsResponse> resolve(
-      String flag, Struct context, Boolean isProvider) {
+      String flag, Struct context, String providerId) {
     return GrpcUtil.toCompletableFuture(
         stub.withDeadlineAfter(10, TimeUnit.SECONDS)
             .resolveFlags(
@@ -34,15 +38,18 @@ public class GrpcFlagResolver implements FlagResolver {
                     .setClientSecret(this.clientSecret)
                     .addAllFlags(List.of(flag))
                     .setEvaluationContext(context)
-                    .setSdk(
-                        sdkBuilder
-                            .setId(
-                                isProvider
-                                    ? SdkId.SDK_ID_JAVA_PROVIDER
-                                    : SdkId.SDK_ID_JAVA_CONFIDENCE)
-                            .build())
+                    .setSdk(getSdkId(metadata, providerId))
                     .setApply(true)
                     .build()));
+  }
+
+  private Sdk getSdkId(ConfidenceMetadata metadata, String providerId) {
+    try {
+      sdkBuilder.setId(SdkId.valueOf(providerId));
+    } catch (IllegalArgumentException e) {
+      sdkBuilder.setCustomId(providerId);
+    }
+    return sdkBuilder.build();
   }
 
   public void close() {

--- a/sdk-java/src/test/java/com/spotify/confidence/ConfidenceContextTest.java
+++ b/sdk-java/src/test/java/com/spotify/confidence/ConfidenceContextTest.java
@@ -15,7 +15,7 @@ public class ConfidenceContextTest {
 
   @Test
   public void testThrowInvalidContextInMessage() {
-    final Confidence root = Confidence.create(fakeEngine, fakeFlagResolverClient);
+    final ConfidenceInstance root = Confidence.create(fakeEngine, fakeFlagResolverClient);
     assertThrows(
         Exceptions.InvalidContextInMessaageError.class,
         () ->
@@ -24,7 +24,7 @@ public class ConfidenceContextTest {
 
   @Test
   public void getContextContainsParentContextValues() {
-    final Confidence root = Confidence.create(fakeEngine, fakeFlagResolverClient);
+    final ConfidenceInstance root = Confidence.create(fakeEngine, fakeFlagResolverClient);
     root.updateContextEntry("page", ConfidenceValue.of("http://.."));
     final EventSender confidence =
         root.withContext(ImmutableMap.of("pants", ConfidenceValue.of("yellow")));
@@ -41,7 +41,7 @@ public class ConfidenceContextTest {
 
   @Test
   public void setContextOverwritesContext() {
-    final Confidence root = Confidence.create(fakeEngine, fakeFlagResolverClient);
+    final ConfidenceInstance root = Confidence.create(fakeEngine, fakeFlagResolverClient);
     root.updateContextEntry("page", ConfidenceValue.of("http://.."));
     final EventSender confidence =
         root.withContext(ImmutableMap.of("pants", ConfidenceValue.of("yellow")));
@@ -65,7 +65,7 @@ public class ConfidenceContextTest {
 
   @Test
   public void parentContextFieldCanBeOverridden() {
-    final Confidence root = Confidence.create(fakeEngine, fakeFlagResolverClient);
+    final ConfidenceInstance root = Confidence.create(fakeEngine, fakeFlagResolverClient);
     root.updateContextEntry("pants-color", ConfidenceValue.of("yellow"));
     final EventSender confidence =
         root.withContext(ImmutableMap.of("pants-color", ConfidenceValue.of("blue")));
@@ -83,7 +83,7 @@ public class ConfidenceContextTest {
 
   @Test
   public void parentContextFieldCanBeOverriddenOrRemoved() {
-    final Confidence root = Confidence.create(fakeEngine, fakeFlagResolverClient);
+    final ConfidenceInstance root = Confidence.create(fakeEngine, fakeFlagResolverClient);
     root.updateContextEntry("pants-color", ConfidenceValue.of("yellow"));
     final EventSender confidence =
         root.withContext(ImmutableMap.of("shirt-color", ConfidenceValue.of("blue")));
@@ -98,9 +98,9 @@ public class ConfidenceContextTest {
 
   @Test
   public void multiLevelContexts() {
-    final Confidence root = Confidence.create(fakeEngine, fakeFlagResolverClient);
+    final ConfidenceInstance root = Confidence.create(fakeEngine, fakeFlagResolverClient);
     final int numberOfLevels = 9;
-    Confidence last = root;
+    EventSender last = root;
     for (int i = 0; i < numberOfLevels; i++) {
       last =
           last.withContext(

--- a/sdk-java/src/test/java/com/spotify/confidence/ConfidenceResourceManagementTest.java
+++ b/sdk-java/src/test/java/com/spotify/confidence/ConfidenceResourceManagementTest.java
@@ -4,13 +4,12 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.concurrent.ExecutionException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class ConfidenceResourceManagementTest {
 
-  private Confidence root;
+  private ConfidenceInstance root;
   private FakeEventSenderEngine fakeEngine;
   private ResolverClientTestUtils.FakeFlagResolverClient fakeFlagResolverClient;
 
@@ -22,15 +21,8 @@ public class ConfidenceResourceManagementTest {
   }
 
   @Test
-  public void testCloseChildShouldThrowFromResolveFlags() throws IOException {
-    final Confidence child = root.withContext(Map.of("child-key", ConfidenceValue.of("child")));
-    child.close();
-    assertThrows(IllegalStateException.class, () -> child.resolveFlags("test", false).get());
-  }
-
-  @Test
   public void testCloseChildShouldNotCloseParentEngine() throws IOException {
-    final Confidence child = root.withContext(Map.of("child-key", ConfidenceValue.of("child")));
+    final EventSender child = root.withContext(Map.of("child-key", ConfidenceValue.of("child")));
     child.close();
     assertFalse(fakeEngine.closed);
     assertFalse(fakeFlagResolverClient.closed);
@@ -38,27 +30,8 @@ public class ConfidenceResourceManagementTest {
 
   @Test
   public void testCloseChildShouldNotThrowFromSend() throws IOException {
-    final Confidence child = root.withContext(Map.of("child-key", ConfidenceValue.of("child")));
+    final EventSender child = root.withContext(Map.of("child-key", ConfidenceValue.of("child")));
     child.close();
     child.track("Test");
-  }
-
-  @Test
-  public void testCloseChildShouldNotAffectParent()
-      throws IOException, ExecutionException, InterruptedException {
-    final Confidence child = root.withContext(Map.of("child-key", ConfidenceValue.of("child")));
-    child.close();
-    root.resolveFlags("test", false).get();
-    root.track("test", ConfidenceValue.of(Map.of("messageKey", ConfidenceValue.of("parent"))));
-  }
-
-  @Test
-  public void testCloseParentShouldAffectChild() throws IOException {
-    final Confidence child = root.withContext(Map.of("child-key", ConfidenceValue.of("child")));
-    root.close();
-    assertThrows(IllegalStateException.class, () -> child.resolveFlags("test", false).get());
-    assertThrows(IllegalStateException.class, () -> root.resolveFlags("test", false).get());
-    assertTrue(fakeEngine.closed);
-    assertTrue(fakeFlagResolverClient.closed);
   }
 }

--- a/sdk-java/src/test/java/com/spotify/confidence/ConfidenceTest.java
+++ b/sdk-java/src/test/java/com/spotify/confidence/ConfidenceTest.java
@@ -22,7 +22,7 @@ final class ConfidenceTest {
   private final FakeEventSenderEngine fakeEngine = new FakeEventSenderEngine(new FakeClock());
   private final ResolverClientTestUtils.FakeFlagResolverClient fakeFlagResolverClient =
       new ResolverClientTestUtils.FakeFlagResolverClient();
-  private static Confidence confidence;
+  private static ConfidenceInstance confidence;
 
   @BeforeEach
   void beforeEach() {
@@ -244,7 +244,8 @@ final class ConfidenceTest {
 
   @Test
   void internalError() {
-    final Confidence confidence = Confidence.create(fakeEngine, new FailingFlagResolverClient());
+    final ConfidenceInstance confidence =
+        Confidence.create(fakeEngine, new FailingFlagResolverClient());
     final Integer value = confidence.getValue("no-match-flag", 20);
     assertEquals(20, value);
 
@@ -262,7 +263,7 @@ final class ConfidenceTest {
 
     @Override
     public CompletableFuture<ResolveFlagsResponse> resolveFlags(
-        String flag, Struct context, Boolean isProvider) {
+        String flag, Struct context, String providerId) {
       throw new RuntimeException("Crashing while performing network call");
     }
 

--- a/sdk-java/src/test/java/com/spotify/confidence/GrpcEventUploaderTest.java
+++ b/sdk-java/src/test/java/com/spotify/confidence/GrpcEventUploaderTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.protobuf.Timestamp;
+import com.spotify.confidence.Confidence.ConfidenceMetadata;
 import com.spotify.confidence.events.v1.EventError;
 import com.spotify.confidence.events.v1.EventError.Reason;
 import com.spotify.confidence.events.v1.EventsServiceGrpc;
@@ -54,7 +55,8 @@ class GrpcEventUploaderTest {
     fakeClock.setCurrentTimeSeconds(1337);
 
     // Create a client that uses the channel
-    uploader = new GrpcEventUploader("my-client-secret", fakeClock, channel);
+    uploader =
+        new GrpcEventUploader("my-client-secret", fakeClock, channel, new ConfidenceMetadata(""));
   }
 
   @AfterEach

--- a/sdk-java/src/test/java/com/spotify/confidence/ResolverClientTestUtils.java
+++ b/sdk-java/src/test/java/com/spotify/confidence/ResolverClientTestUtils.java
@@ -24,7 +24,7 @@ public class ResolverClientTestUtils {
 
     @Override
     public CompletableFuture<ResolveFlagsResponse> resolveFlags(
-        String flag, ConfidenceValue.Struct context, Boolean isProvider) {
+        String flag, ConfidenceValue.Struct context, String providerId) {
       resolves.put(flag, context);
       return CompletableFuture.completedFuture(response);
     }


### PR DESCRIPTION
- Confidence has two builder outputs:
  - Regular `build` that returns a `ConfidenceInstance`, for users to resolve and upload events;
  - A `buildForProvider` (meant to be used only by the Confidence Provider), which returns a `FlagReaderForProvider`: this latter interface allows to call `resolve` while passing in a different `SDK_ID`. It also allows to create child resolvers internally, which is instead NOT allowed by the user-facing `ConfidenceInstance` (the latter only allows to create EventSenders as children)

Alternative to #146 