### PR TITLE
docs: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Java library for [Confidence](https://confidence.spotify.com/). This library is 
 ```
 <!---x-release-please-end-->
 
+_Note: we strongly recommend to adopt the latest non-SNAPSHOT release._
+
 #### Depending on a development snapshot
 We deploy snapshots from the `main` branch to [Sonatype OSSRH](https://oss.sonatype.org/content/repositories/snapshots/com/spotify/confidence/sdk-java/).
 To use a snapshot, add the following repository to your `pom.xml`:


### PR DESCRIPTION
I couldn't find a way to tell release please to not use SNAPSHOT releases in the text-replacing logic. This is better than nothing