### PR TITLE
feat: add telemetry on resolve latency

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ The library includes a `Provider` for
 the [OpenFeature Java SDK](https://openfeature.dev/docs/tutorials/getting-started/java), that can be
 used to resolve feature flag values from the Confidence platform.
 
+The constructor for creating an OpenFeature `ConfidenceProvider` takes a `Confidence` instance as a parameter.
+We kindly ask you to use the `Confidence.Builder.buildForProvider()` function when creating a `Confidence` instance that 
+will be used with OpenFeature.
+
 To learn more about the basic concepts (flags, targeting key, evaluation contexts),
 the [OpenFeature reference documentation](https://openfeature.dev/docs/reference/intro) can be
 useful.

--- a/README.md
+++ b/README.md
@@ -63,3 +63,19 @@ used to resolve feature flag values from the Confidence platform.
 To learn more about the basic concepts (flags, targeting key, evaluation contexts),
 the [OpenFeature reference documentation](https://openfeature.dev/docs/reference/intro) can be
 useful.
+
+## Telemetry
+
+In order to improve the services provided by Confidence, the SDK collects a very limited amount of telemetry data. 
+This data is sent in the form of an additional gRPC header with each resolve request. The data does not contain any 
+information that can be used to link the data to a specific end user.
+
+Please refer to the [Telemetry class](sdk-java/src/main/java/com/spotify/confidence/telemetry/Telemetry.java) to understand the data that is collected.
+
+To opt out of this behavior, you can disable telemetry by setting the `disableTelemetry` flag to `true` when building the `Confidence` instance.
+
+```java
+final Confidence confidence = Confidence.Builder("<CLIENT_SECRET>")
+        .disableTelemetry(true)
+        .build();
+```

--- a/openfeature-provider/src/test/java/com/spotify/confidence/FeatureProviderTest.java
+++ b/openfeature-provider/src/test/java/com/spotify/confidence/FeatureProviderTest.java
@@ -4,8 +4,7 @@ import static com.spotify.confidence.ResolverClientTestUtils.generateSampleRespo
 import static dev.openfeature.sdk.ErrorCode.GENERAL;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 
 import com.google.protobuf.util.Structs;
 import com.google.protobuf.util.Values;
@@ -15,6 +14,10 @@ import com.spotify.confidence.shaded.flags.resolver.v1.ResolveFlagsRequest;
 import com.spotify.confidence.shaded.flags.resolver.v1.ResolveFlagsResponse;
 import com.spotify.confidence.shaded.flags.resolver.v1.ResolvedFlag;
 import com.spotify.confidence.shaded.flags.types.v1.FlagSchema;
+import com.spotify.confidence.telemetry.Telemetry;
+import com.spotify.confidence.telemetry.TelemetryClientInterceptor;
+import com.spotify.telemetry.v1.LibraryTraces;
+import com.spotify.telemetry.v1.Monitoring;
 import dev.openfeature.sdk.*;
 import io.grpc.ManagedChannel;
 import io.grpc.Server;
@@ -53,6 +56,7 @@ final class FeatureProviderTest {
       new MutableContext("my-targeting-key", Map.of("my-key", new Value(true)));
 
   static final String serverName = InProcessServerBuilder.generateName();
+  private Telemetry telemetry;
 
   @BeforeAll
   static void before() throws IOException {
@@ -69,8 +73,12 @@ final class FeatureProviderTest {
   void beforeEach() {
     final FakeEventSenderEngine fakeEventSender = new FakeEventSenderEngine(new FakeClock());
     channel = InProcessChannelBuilder.forName(serverName).directExecutor().build();
+    telemetry = new Telemetry();
+    final TelemetryClientInterceptor telemetryInterceptor =
+        new TelemetryClientInterceptor(telemetry);
     final FlagResolverClientImpl flagResolver =
-        new FlagResolverClientImpl(new GrpcFlagResolver("fake-secret", channel));
+        new FlagResolverClientImpl(
+            new GrpcFlagResolver("fake-secret", channel, telemetryInterceptor), telemetry);
     final Confidence confidence = Confidence.create(fakeEventSender, flagResolver);
     final FeatureProvider featureProvider = new ConfidenceFeatureProvider(confidence);
 
@@ -506,6 +514,25 @@ final class FeatureProviderTest {
 
     assertThat(state).isEqualTo(ProviderState.NOT_READY);
     assertThat(evaluationDetails.getValue()).isEqualTo(defaultValue);
+  }
+
+  @Test
+  public void resolvesContainHeaderWithTelemetryData() {
+    mockSampleResponse();
+
+    client.getIntegerDetails("flag.prop-E", 1000, SAMPLE_CONTEXT);
+
+    final Monitoring telemetrySnapshot = telemetry.peekSnapshot();
+    final List<LibraryTraces> libraryTracesList = telemetrySnapshot.getLibraryTracesList();
+    assertThat(libraryTracesList).hasSize(1);
+    final LibraryTraces traces = libraryTracesList.get(0);
+    assertThat(traces.getLibrary()).isEqualTo(LibraryTraces.Library.LIBRARY_OPEN_FEATURE);
+    assertThat(traces.getTracesList()).hasSize(1);
+    final LibraryTraces.Trace trace = traces.getTraces(0);
+    assertThat(trace.getId()).isEqualTo(LibraryTraces.TraceId.TRACE_ID_RESOLVE_LATENCY);
+    assertThat(trace.getMillisecondDuration()).isNotNegative();
+
+    client.getIntegerDetails("flag.prop-Y", 1000, SAMPLE_CONTEXT);
   }
 
   //////

--- a/openfeature-provider/src/test/java/com/spotify/confidence/FeatureProviderTest.java
+++ b/openfeature-provider/src/test/java/com/spotify/confidence/FeatureProviderTest.java
@@ -73,7 +73,7 @@ final class FeatureProviderTest {
   void beforeEach() {
     final FakeEventSenderEngine fakeEventSender = new FakeEventSenderEngine(new FakeClock());
     channel = InProcessChannelBuilder.forName(serverName).directExecutor().build();
-    telemetry = new Telemetry();
+    telemetry = new Telemetry(true);
     final TelemetryClientInterceptor telemetryInterceptor =
         new TelemetryClientInterceptor(telemetry);
     final FlagResolverClientImpl flagResolver =
@@ -522,7 +522,7 @@ final class FeatureProviderTest {
 
     client.getIntegerDetails("flag.prop-E", 1000, SAMPLE_CONTEXT);
 
-    final Monitoring telemetrySnapshot = telemetry.peekSnapshot();
+    final Monitoring telemetrySnapshot = telemetry.getSnapshotInternal();
     final List<LibraryTraces> libraryTracesList = telemetrySnapshot.getLibraryTracesList();
     assertThat(libraryTracesList).hasSize(1);
     final LibraryTraces traces = libraryTracesList.get(0);

--- a/openfeature-provider/src/test/java/com/spotify/confidence/FlagResolverContextTest.java
+++ b/openfeature-provider/src/test/java/com/spotify/confidence/FlagResolverContextTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.protobuf.Struct;
 import com.spotify.confidence.shaded.flags.resolver.v1.ResolveFlagsResponse;
-import com.spotify.confidence.telemetry.Telemetry;
 import dev.openfeature.sdk.*;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -15,15 +14,12 @@ public class FlagResolverContextTest {
   private FakeFlagResolver fakeFlagResolver;
   private Client client;
   private Confidence confidence;
-  private Telemetry telemetry;
 
   @BeforeEach
   void beforeEach() {
     final FakeEventSenderEngine fakeEventSender = new FakeEventSenderEngine(new FakeClock());
     this.fakeFlagResolver = new FakeFlagResolver();
-    this.telemetry = new Telemetry();
-    final FlagResolverClientImpl flagResolver =
-        new FlagResolverClientImpl(fakeFlagResolver, telemetry);
+    final FlagResolverClientImpl flagResolver = new FlagResolverClientImpl(fakeFlagResolver, null);
     this.confidence = Confidence.create(fakeEventSender, flagResolver);
     final FeatureProvider featureProvider = new ConfidenceFeatureProvider(confidence);
 

--- a/openfeature-provider/src/test/java/com/spotify/confidence/FlagResolverContextTest.java
+++ b/openfeature-provider/src/test/java/com/spotify/confidence/FlagResolverContextTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.protobuf.Struct;
 import com.spotify.confidence.shaded.flags.resolver.v1.ResolveFlagsResponse;
+import com.spotify.confidence.telemetry.Telemetry;
 import dev.openfeature.sdk.*;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -14,12 +15,15 @@ public class FlagResolverContextTest {
   private FakeFlagResolver fakeFlagResolver;
   private Client client;
   private Confidence confidence;
+  private Telemetry telemetry;
 
   @BeforeEach
   void beforeEach() {
     final FakeEventSenderEngine fakeEventSender = new FakeEventSenderEngine(new FakeClock());
     this.fakeFlagResolver = new FakeFlagResolver();
-    final FlagResolverClientImpl flagResolver = new FlagResolverClientImpl(fakeFlagResolver);
+    this.telemetry = new Telemetry();
+    final FlagResolverClientImpl flagResolver =
+        new FlagResolverClientImpl(fakeFlagResolver, telemetry);
     this.confidence = Confidence.create(fakeEventSender, flagResolver);
     final FeatureProvider featureProvider = new ConfidenceFeatureProvider(confidence);
 

--- a/openfeature-provider/src/test/java/com/spotify/confidence/FlagResolverContextTest.java
+++ b/openfeature-provider/src/test/java/com/spotify/confidence/FlagResolverContextTest.java
@@ -19,7 +19,7 @@ public class FlagResolverContextTest {
   void beforeEach() {
     final FakeEventSenderEngine fakeEventSender = new FakeEventSenderEngine(new FakeClock());
     this.fakeFlagResolver = new FakeFlagResolver();
-    final FlagResolverClientImpl flagResolver = new FlagResolverClientImpl(fakeFlagResolver, null);
+    final FlagResolverClientImpl flagResolver = new FlagResolverClientImpl(fakeFlagResolver);
     this.confidence = Confidence.create(fakeEventSender, flagResolver);
     final FeatureProvider featureProvider = new ConfidenceFeatureProvider(confidence);
 

--- a/sdk-java/src/main/java/com/spotify/confidence/Confidence.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/Confidence.java
@@ -313,7 +313,7 @@ public abstract class Confidence implements EventSender, Closeable {
             .keepAliveTime(Duration.ofMinutes(5).getSeconds(), TimeUnit.SECONDS)
             .build();
     private ManagedChannel flagResolverManagedChannel = DEFAULT_CHANNEL;
-    private boolean disableTelemetry = true;
+    private boolean disableTelemetry = false;
 
     public Builder(@Nonnull String clientSecret) {
       this.clientSecret = clientSecret;

--- a/sdk-java/src/main/java/com/spotify/confidence/Confidence.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/Confidence.java
@@ -314,6 +314,7 @@ public abstract class Confidence implements EventSender, Closeable {
             .build();
     private ManagedChannel flagResolverManagedChannel = DEFAULT_CHANNEL;
     private boolean disableTelemetry = false;
+    private boolean isProvider = false;
 
     public Builder(@Nonnull String clientSecret) {
       this.clientSecret = clientSecret;
@@ -337,9 +338,14 @@ public abstract class Confidence implements EventSender, Closeable {
       return this;
     }
 
+    public Confidence buildForProvider() {
+      this.isProvider = true;
+      return build();
+    }
+
     public Confidence build() {
       final FlagResolverClient flagResolverClient;
-      final Telemetry telemetry = disableTelemetry ? null : new Telemetry();
+      final Telemetry telemetry = disableTelemetry ? null : new Telemetry(isProvider);
       final TelemetryClientInterceptor telemetryInterceptor =
           new TelemetryClientInterceptor(telemetry);
       final GrpcFlagResolver flagResolver =

--- a/sdk-java/src/main/java/com/spotify/confidence/Confidence.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/Confidence.java
@@ -339,21 +339,13 @@ public abstract class Confidence implements EventSender, Closeable {
 
     public Confidence build() {
       final FlagResolverClient flagResolverClient;
-      final Telemetry telemetry;
-      if (disableTelemetry) {
-        flagResolverClient =
-            new FlagResolverClientImpl(
-                new GrpcFlagResolver(clientSecret, flagResolverManagedChannel));
-      } else {
-        telemetry = new Telemetry();
-        final TelemetryClientInterceptor telemetryInterceptor =
-            new TelemetryClientInterceptor(telemetry);
-        flagResolverClient =
-            new FlagResolverClientImpl(
-                new GrpcFlagResolver(
-                    clientSecret, flagResolverManagedChannel, telemetryInterceptor),
-                telemetry);
-      }
+      final Telemetry telemetry = disableTelemetry ? null : new Telemetry();
+      final TelemetryClientInterceptor telemetryInterceptor =
+          new TelemetryClientInterceptor(telemetry);
+      final GrpcFlagResolver flagResolver =
+          new GrpcFlagResolver(clientSecret, flagResolverManagedChannel, telemetryInterceptor);
+
+      flagResolverClient = new FlagResolverClientImpl(flagResolver, telemetry);
 
       final EventSenderEngine eventSenderEngine =
           new EventSenderEngineImpl(clientSecret, DEFAULT_CHANNEL, Instant::now);

--- a/sdk-java/src/main/java/com/spotify/confidence/Confidence.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/Confidence.java
@@ -16,8 +16,11 @@ import com.spotify.confidence.Exceptions.IncompatibleValueType;
 import com.spotify.confidence.Exceptions.ValueNotFound;
 import com.spotify.confidence.shaded.flags.resolver.v1.ResolveFlagsResponse;
 import com.spotify.confidence.shaded.flags.resolver.v1.ResolvedFlag;
+import com.spotify.confidence.telemetry.Telemetry;
+import com.spotify.confidence.telemetry.TelemetryClientInterceptor;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.StatusRuntimeException;
 import java.io.Closeable;
 import java.io.IOException;
 import java.time.Duration;
@@ -168,8 +171,17 @@ public abstract class Confidence implements EventSender, Closeable {
       log.warn(e.getMessage());
       return new FlagEvaluation<>(
           defaultValue, "", "ERROR", ErrorType.INVALID_VALUE_TYPE, e.getMessage());
+    } catch (StatusRuntimeException e) {
+      log.warn(e.getMessage());
+      return new FlagEvaluation<>(
+          defaultValue, "", "ERROR", ErrorType.NETWORK_ERROR, e.getMessage());
     } catch (Exception e) {
       // catch all for any runtime exception
+      if (e.getCause() instanceof StatusRuntimeException) {
+        log.warn(e.getMessage());
+        return new FlagEvaluation<>(
+            defaultValue, "", "ERROR", ErrorType.NETWORK_ERROR, e.getMessage());
+      }
       log.warn(e.getMessage());
       return new FlagEvaluation<>(
           defaultValue, "", "ERROR", ErrorType.INTERNAL_ERROR, e.getMessage());
@@ -320,9 +332,13 @@ public abstract class Confidence implements EventSender, Closeable {
     }
 
     public Confidence build() {
+      final Telemetry telemetry = new Telemetry();
+      final TelemetryClientInterceptor telemetryInterceptor =
+          new TelemetryClientInterceptor(telemetry);
       final FlagResolverClient flagResolverClient =
           new FlagResolverClientImpl(
-              new GrpcFlagResolver(clientSecret, flagResolverManagedChannel));
+              new GrpcFlagResolver(clientSecret, flagResolverManagedChannel, telemetryInterceptor),
+              telemetry);
       final EventSenderEngine eventSenderEngine =
           new EventSenderEngineImpl(clientSecret, DEFAULT_CHANNEL, Instant::now);
       closer.register(flagResolverClient);

--- a/sdk-java/src/main/java/com/spotify/confidence/ConfidenceTypeMapper.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/ConfidenceTypeMapper.java
@@ -30,7 +30,8 @@ class ConfidenceTypeMapper {
             if (intVal != value.getNumberValue()) {
               throw new ParseError(
                   String.format(
-                      "%s %s should be an int, but it is a double/long", mismatchPrefix, value));
+                      "%s %s should be an int, but it is a double/long",
+                      mismatchPrefix, value.getNumberValue()));
             }
             return ConfidenceValue.of(intVal);
           case DOUBLE_SCHEMA:

--- a/sdk-java/src/main/java/com/spotify/confidence/ConfidenceValue.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/ConfidenceValue.java
@@ -26,6 +26,11 @@ public abstract class ConfidenceValue {
         public com.google.protobuf.Value toProto() {
           return com.google.protobuf.Value.newBuilder().setNullValue(NullValue.NULL_VALUE).build();
         }
+
+        @Override
+        public String toString() {
+          return "NULL";
+        }
       };
 
   private ConfidenceValue() {}

--- a/sdk-java/src/main/java/com/spotify/confidence/FlagResolverClientImpl.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/FlagResolverClientImpl.java
@@ -19,11 +19,6 @@ class FlagResolverClientImpl implements FlagResolverClient {
     this.telemetry = telemetry;
   }
 
-  public FlagResolverClientImpl(FlagResolver grpcFlagResolver) {
-    this.grpcFlagResolver = grpcFlagResolver;
-    this.telemetry = null;
-  }
-
   public CompletableFuture<ResolveFlagsResponse> resolveFlags(
       String flagName, ConfidenceValue.Struct context, Boolean isProvider) {
     final Instant start = Instant.now();

--- a/sdk-java/src/main/java/com/spotify/confidence/FlagResolverClientImpl.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/FlagResolverClientImpl.java
@@ -19,6 +19,10 @@ class FlagResolverClientImpl implements FlagResolverClient {
     this.telemetry = telemetry;
   }
 
+  public FlagResolverClientImpl(FlagResolver grpcFlagResolver) {
+    this(grpcFlagResolver, null);
+  }
+
   public CompletableFuture<ResolveFlagsResponse> resolveFlags(
       String flagName, ConfidenceValue.Struct context, Boolean isProvider) {
     final Instant start = Instant.now();

--- a/sdk-java/src/main/java/com/spotify/confidence/FlagResolverClientImpl.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/FlagResolverClientImpl.java
@@ -3,18 +3,25 @@ package com.spotify.confidence;
 import com.google.protobuf.Struct;
 import com.google.protobuf.Value;
 import com.spotify.confidence.shaded.flags.resolver.v1.ResolveFlagsResponse;
+import com.spotify.confidence.telemetry.Telemetry;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.concurrent.CompletableFuture;
 
 class FlagResolverClientImpl implements FlagResolverClient {
   public static final String OPEN_FEATURE_RESOLVE_CONTEXT_KEY = "open-feature";
   private final FlagResolver grpcFlagResolver;
+  private final Telemetry telemetry;
 
-  public FlagResolverClientImpl(FlagResolver grpcFlagResolver) {
+  public FlagResolverClientImpl(FlagResolver grpcFlagResolver, Telemetry telemetry) {
     this.grpcFlagResolver = grpcFlagResolver;
+    this.telemetry = telemetry;
   }
 
   public CompletableFuture<ResolveFlagsResponse> resolveFlags(
       String flagName, ConfidenceValue.Struct context, Boolean isProvider) {
+    final Instant start = Instant.now();
+
     final Struct.Builder evaluationContextBuilder = context.toProto().getStructValue().toBuilder();
     if (context.asMap().containsKey(OPEN_FEATURE_RESOLVE_CONTEXT_KEY)) {
       final Value openFeatureEvaluationContext =
@@ -24,8 +31,15 @@ class FlagResolverClientImpl implements FlagResolverClient {
           openFeatureEvaluationContext.getStructValue().getFieldsMap());
       evaluationContextBuilder.removeFields(OPEN_FEATURE_RESOLVE_CONTEXT_KEY);
     }
-
-    return this.grpcFlagResolver.resolve(flagName, evaluationContextBuilder.build(), isProvider);
+    telemetry.setIsProvider(isProvider);
+    return this.grpcFlagResolver
+        .resolve(flagName, evaluationContextBuilder.build(), isProvider)
+        .thenApply(
+            response -> {
+              final Instant end = Instant.now();
+              telemetry.appendLatency(Duration.between(start, end).toMillis());
+              return response;
+            });
   }
 
   @Override

--- a/sdk-java/src/main/java/com/spotify/confidence/FlagResolverClientImpl.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/FlagResolverClientImpl.java
@@ -12,7 +12,7 @@ import javax.annotation.Nullable;
 class FlagResolverClientImpl implements FlagResolverClient {
   public static final String OPEN_FEATURE_RESOLVE_CONTEXT_KEY = "open-feature";
   private final FlagResolver grpcFlagResolver;
-  private final Telemetry telemetry;
+  private final @Nullable Telemetry telemetry;
 
   public FlagResolverClientImpl(FlagResolver grpcFlagResolver, @Nullable Telemetry telemetry) {
     this.grpcFlagResolver = grpcFlagResolver;
@@ -35,9 +35,6 @@ class FlagResolverClientImpl implements FlagResolverClient {
       evaluationContextBuilder.putAllFields(
           openFeatureEvaluationContext.getStructValue().getFieldsMap());
       evaluationContextBuilder.removeFields(OPEN_FEATURE_RESOLVE_CONTEXT_KEY);
-    }
-    if (telemetry != null) {
-      telemetry.setIsProvider(isProvider);
     }
 
     return this.grpcFlagResolver

--- a/sdk-java/src/main/java/com/spotify/confidence/GrpcFlagResolver.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/GrpcFlagResolver.java
@@ -9,7 +9,6 @@ import io.grpc.ManagedChannel;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nullable;
 
 public class GrpcFlagResolver implements FlagResolver {
   private final ManagedChannel managedChannel;
@@ -21,23 +20,15 @@ public class GrpcFlagResolver implements FlagResolver {
   public GrpcFlagResolver(
       String clientSecret,
       ManagedChannel managedChannel,
-      @Nullable TelemetryClientInterceptor telemetryInterceptor) {
+      TelemetryClientInterceptor telemetryInterceptor) {
     if (Strings.isNullOrEmpty(clientSecret)) {
       throw new IllegalArgumentException("clientSecret must be a non-empty string.");
     }
     this.clientSecret = clientSecret;
     this.managedChannel = managedChannel;
-    if (telemetryInterceptor != null) {
-      this.stub =
-          FlagResolverServiceGrpc.newFutureStub(managedChannel)
-              .withInterceptors(telemetryInterceptor);
-    } else {
-      this.stub = FlagResolverServiceGrpc.newFutureStub(managedChannel);
-    }
-  }
-
-  public GrpcFlagResolver(String clientSecret, ManagedChannel managedChannel) {
-    this(clientSecret, managedChannel, null);
+    this.stub =
+        FlagResolverServiceGrpc.newFutureStub(managedChannel)
+            .withInterceptors(telemetryInterceptor);
   }
 
   public CompletableFuture<ResolveFlagsResponse> resolve(

--- a/sdk-java/src/main/java/com/spotify/confidence/GrpcFlagResolver.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/GrpcFlagResolver.java
@@ -4,6 +4,7 @@ import com.google.common.base.Strings;
 import com.google.protobuf.Struct;
 import com.spotify.confidence.shaded.flags.resolver.v1.*;
 import com.spotify.confidence.shaded.flags.resolver.v1.Sdk.Builder;
+import com.spotify.confidence.telemetry.TelemetryClientInterceptor;
 import io.grpc.ManagedChannel;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -16,13 +17,18 @@ public class GrpcFlagResolver implements FlagResolver {
 
   private final FlagResolverServiceGrpc.FlagResolverServiceFutureStub stub;
 
-  public GrpcFlagResolver(String clientSecret, ManagedChannel managedChannel) {
+  public GrpcFlagResolver(
+      String clientSecret,
+      ManagedChannel managedChannel,
+      TelemetryClientInterceptor telemetryInterceptor) {
     if (Strings.isNullOrEmpty(clientSecret)) {
       throw new IllegalArgumentException("clientSecret must be a non-empty string.");
     }
     this.clientSecret = clientSecret;
     this.managedChannel = managedChannel;
-    this.stub = FlagResolverServiceGrpc.newFutureStub(managedChannel);
+    this.stub =
+        FlagResolverServiceGrpc.newFutureStub(managedChannel)
+            .withInterceptors(telemetryInterceptor);
   }
 
   public CompletableFuture<ResolveFlagsResponse> resolve(

--- a/sdk-java/src/main/java/com/spotify/confidence/telemetry/Telemetry.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/telemetry/Telemetry.java
@@ -1,0 +1,53 @@
+package com.spotify.confidence.telemetry;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.spotify.telemetry.v1.LibraryTraces;
+import com.spotify.telemetry.v1.Monitoring;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class Telemetry {
+  private final ConcurrentLinkedQueue<LibraryTraces.Trace> latencyTraces =
+      new ConcurrentLinkedQueue<>();
+  private final AtomicBoolean isProvider = new AtomicBoolean(false);
+
+  public void appendLatency(long latency) {
+    latencyTraces.add(
+        LibraryTraces.Trace.newBuilder()
+            .setId(LibraryTraces.TraceId.TRACE_ID_RESOLVE_LATENCY)
+            .setMillisecondDuration(latency)
+            .build());
+  }
+
+  public Monitoring getSnapshot() {
+    final Monitoring snapshot = getSnapshotInternal();
+    clear();
+    return snapshot;
+  }
+
+  private Monitoring getSnapshotInternal() {
+    final LibraryTraces libraryTraces =
+        LibraryTraces.newBuilder()
+            .setLibrary(
+                isProvider.get()
+                    ? LibraryTraces.Library.LIBRARY_OPEN_FEATURE
+                    : LibraryTraces.Library.LIBRARY_CONFIDENCE)
+            .addAllTraces(latencyTraces)
+            .build();
+
+    return Monitoring.newBuilder().addLibraryTraces(libraryTraces).build();
+  }
+
+  @VisibleForTesting
+  public synchronized Monitoring peekSnapshot() {
+    return getSnapshotInternal();
+  }
+
+  private void clear() {
+    latencyTraces.clear();
+  }
+
+  public void setIsProvider(Boolean isProvider) {
+    this.isProvider.set(isProvider);
+  }
+}

--- a/sdk-java/src/main/java/com/spotify/confidence/telemetry/TelemetryClientInterceptor.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/telemetry/TelemetryClientInterceptor.java
@@ -1,0 +1,31 @@
+package com.spotify.confidence.telemetry;
+
+import com.spotify.telemetry.v1.Monitoring;
+import io.grpc.*;
+import java.util.Base64;
+
+public class TelemetryClientInterceptor implements ClientInterceptor {
+  public static final Metadata.Key<String> HEADER_KEY =
+      Metadata.Key.of("X-CONFIDENCE-TELEMETRY", Metadata.ASCII_STRING_MARSHALLER);
+  private final Telemetry telemetry;
+
+  public TelemetryClientInterceptor(Telemetry telemetry) {
+    this.telemetry = telemetry;
+  }
+
+  @Override
+  public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+      MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+    return new ForwardingClientCall.SimpleForwardingClientCall<>(
+        next.newCall(method, callOptions)) {
+      @Override
+      public void start(Listener<RespT> responseListener, Metadata headers) {
+        final Monitoring telemetrySnapshot = telemetry.getSnapshot();
+        final String base64Telemetry =
+            Base64.getEncoder().encodeToString(telemetrySnapshot.toByteArray());
+        headers.put(HEADER_KEY, base64Telemetry);
+        super.start(responseListener, headers);
+      }
+    };
+  }
+}

--- a/sdk-java/src/main/proto/confidence/telemetry.proto
+++ b/sdk-java/src/main/proto/confidence/telemetry.proto
@@ -1,0 +1,37 @@
+syntax = "proto3";
+
+package confidence.telemetry.v1;
+option java_package = "com.spotify.telemetry.v1";
+option java_multiple_files = true;
+option java_outer_classname = "TelemetryProto";
+
+message Monitoring {
+  repeated LibraryTraces library_traces = 1;
+}
+
+message LibraryTraces {
+  Library library = 1;
+  string library_version = 2;
+  repeated Trace traces = 3;
+
+  message Trace {
+    TraceId id = 1;
+    // only used for timed events.
+    optional uint64 millisecond_duration = 2;
+  }
+
+  enum Library {
+    LIBRARY_UNSPECIFIED = 0;
+    LIBRARY_CONFIDENCE = 1;
+    LIBRARY_OPEN_FEATURE = 2;
+    LIBRARY_REACT = 3;
+  }
+
+  enum TraceId {
+    TRACE_ID_UNSPECIFIED = 0;
+    TRACE_ID_RESOLVE_LATENCY = 1;
+    TRACE_ID_STALE_FLAG = 2;
+    TRACE_ID_FLAG_TYPE_MISMATCH = 3;
+    TRACE_ID_WITH_CONTEXT = 4;
+  }
+}

--- a/sdk-java/src/test/java/com/spotify/confidence/ConfidenceIntegrationTest.java
+++ b/sdk-java/src/test/java/com/spotify/confidence/ConfidenceIntegrationTest.java
@@ -453,7 +453,7 @@ final class ConfidenceIntegrationTest {
 
     confidence.withContext(SAMPLE_CONTEXT).getEvaluation("flag.prop-E", 1000);
 
-    final Monitoring telemetrySnapshot = telemetry.peekSnapshot();
+    final Monitoring telemetrySnapshot = telemetry.getSnapshotInternal();
     final List<LibraryTraces> libraryTracesList = telemetrySnapshot.getLibraryTracesList();
     assertThat(libraryTracesList).hasSize(1);
     final LibraryTraces traces = libraryTracesList.get(0);

--- a/sdk-java/src/test/java/com/spotify/confidence/ConfidenceIntegrationTest.java
+++ b/sdk-java/src/test/java/com/spotify/confidence/ConfidenceIntegrationTest.java
@@ -479,7 +479,7 @@ final class ConfidenceIntegrationTest {
         new FakeTelemetryClientInterceptor(null);
     final FlagResolverClientImpl flagResolver =
         new FlagResolverClientImpl(
-            new GrpcFlagResolver("fake-secret", channel, nullTelemetryInterceptor), null);
+            new GrpcFlagResolver("fake-secret", channel, nullTelemetryInterceptor));
     confidence = Confidence.create(fakeEventSender, flagResolver);
 
     mockSampleResponse();

--- a/sdk-java/src/test/java/com/spotify/confidence/ConfidenceIntegrationTest.java
+++ b/sdk-java/src/test/java/com/spotify/confidence/ConfidenceIntegrationTest.java
@@ -1,0 +1,502 @@
+package com.spotify.confidence;
+
+import static com.spotify.confidence.ErrorType.*;
+import static com.spotify.confidence.ResolverClientTestUtils.generateSampleResponse;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import com.google.protobuf.util.Structs;
+import com.google.protobuf.util.Values;
+import com.spotify.confidence.ResolverClientTestUtils.ValueSchemaHolder;
+import com.spotify.confidence.shaded.flags.resolver.v1.FlagResolverServiceGrpc.FlagResolverServiceImplBase;
+import com.spotify.confidence.shaded.flags.resolver.v1.ResolveFlagsRequest;
+import com.spotify.confidence.shaded.flags.resolver.v1.ResolveFlagsResponse;
+import com.spotify.confidence.shaded.flags.resolver.v1.ResolvedFlag;
+import com.spotify.confidence.shaded.flags.types.v1.FlagSchema;
+import com.spotify.confidence.telemetry.FakeTelemetryClientInterceptor;
+import com.spotify.confidence.telemetry.Telemetry;
+import com.spotify.confidence.telemetry.TelemetryClientInterceptor;
+import com.spotify.telemetry.v1.LibraryTraces;
+import com.spotify.telemetry.v1.Monitoring;
+import io.grpc.ManagedChannel;
+import io.grpc.Metadata;
+import io.grpc.Server;
+import io.grpc.Status;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+final class ConfidenceIntegrationTest {
+  private static Server server;
+  private static ManagedChannel channel;
+
+  private static final FlagResolverServiceImplBase serviceImpl =
+      mock(FlagResolverServiceImplBase.class);
+
+  private static final Map<String, ConfidenceValue> SAMPLE_CONTEXT_WITHOUT_TARGETING_KEY =
+      Map.of("my-key", ConfidenceValue.of(true));
+
+  private static final String DEFAULT_VALUE = "string-default";
+
+  private static final Map<String, ConfidenceValue> SAMPLE_CONTEXT =
+      Map.of(
+          "my-targeting-key",
+          ConfidenceValue.of("the-target-id"),
+          "my-key",
+          ConfidenceValue.of(true));
+
+  static final String serverName = InProcessServerBuilder.generateName();
+  private Telemetry telemetry;
+  private Confidence confidence;
+  private FakeTelemetryClientInterceptor telemetryInterceptor;
+
+  @BeforeAll
+  static void before() throws IOException {
+
+    server =
+        InProcessServerBuilder.forName(serverName)
+            .directExecutor()
+            .addService(serviceImpl)
+            .build()
+            .start();
+  }
+
+  @BeforeEach
+  void beforeEach() {
+    final FakeEventSenderEngine fakeEventSender = new FakeEventSenderEngine(new FakeClock());
+    channel = InProcessChannelBuilder.forName(serverName).directExecutor().build();
+    telemetry = new Telemetry();
+    telemetryInterceptor = new FakeTelemetryClientInterceptor(telemetry);
+    final FlagResolverClientImpl flagResolver =
+        new FlagResolverClientImpl(
+            new GrpcFlagResolver("fake-secret", channel, telemetryInterceptor), telemetry);
+    confidence = Confidence.create(fakeEventSender, flagResolver);
+  }
+
+  @AfterAll
+  static void after() {
+    channel.shutdownNow();
+    server.shutdownNow();
+  }
+
+  @Test
+  public void nonExistingFlag() {
+
+    mockResolve(
+        (request, streamObserver) -> {
+          streamObserver.onNext(ResolveFlagsResponse.getDefaultInstance());
+          streamObserver.onCompleted();
+        });
+
+    final FlagEvaluation<String> evaluationDetails =
+        confidence.withContext(SAMPLE_CONTEXT).getEvaluation("not-existing", DEFAULT_VALUE);
+
+    assertThat(evaluationDetails.getValue()).isEqualTo(DEFAULT_VALUE);
+    assertThat(evaluationDetails.getErrorType().get()).isEqualTo(FLAG_NOT_FOUND);
+    assertThat(evaluationDetails.getReason()).isEqualTo("ERROR");
+    assertThat(evaluationDetails.getVariant()).isEmpty();
+    assertThat(evaluationDetails.getErrorMessage().get())
+        .isEqualTo("No active flag 'not-existing' was found");
+  }
+
+  @Test
+  public void unexpectedFlag() {
+
+    mockResolve(
+        (request, streamObserver) -> {
+          streamObserver.onNext(
+              ResolveFlagsResponse.newBuilder()
+                  .addResolvedFlags(
+                      ResolvedFlag.newBuilder().setFlag("flags/unexpected-flag").build())
+                  .build());
+          streamObserver.onCompleted();
+        });
+
+    final FlagEvaluation<String> evaluationDetails =
+        confidence.withContext(SAMPLE_CONTEXT).getEvaluation("flag", DEFAULT_VALUE);
+
+    assertThat(evaluationDetails.getValue()).isEqualTo(DEFAULT_VALUE);
+    assertThat(evaluationDetails.getErrorType().get()).isEqualTo(INTERNAL_ERROR);
+    assertThat(evaluationDetails.getReason()).isEqualTo("ERROR");
+    assertThat(evaluationDetails.getVariant()).isEmpty();
+    assertThat(evaluationDetails.getErrorMessage().get())
+        .isEqualTo("Unexpected flag 'unexpected-flag' from remote");
+  }
+
+  @Test
+  public void unavailableApi() {
+
+    mockResolve(
+        (request, streamObserver) -> streamObserver.onError(Status.UNAVAILABLE.asException()));
+
+    final FlagEvaluation<String> evaluationDetails =
+        confidence.withContext(SAMPLE_CONTEXT).getEvaluation("flags/whatever", DEFAULT_VALUE);
+
+    assertThat(evaluationDetails.getValue()).isEqualTo(DEFAULT_VALUE);
+    assertThat(evaluationDetails.getErrorType().get()).isEqualTo(ErrorType.NETWORK_ERROR);
+    assertThat(evaluationDetails.getReason()).isEqualTo("ERROR");
+    assertThat(evaluationDetails.getErrorMessage().get())
+        .isEqualTo("io.grpc.StatusRuntimeException: UNAVAILABLE");
+    assertThat(evaluationDetails.getVariant()).isEmpty();
+  }
+
+  @Test
+  public void unauthenticated() {
+
+    mockResolve(
+        (request, streamObserver) -> streamObserver.onError(Status.UNAUTHENTICATED.asException()));
+    final FlagEvaluation<String> evaluationDetails =
+        confidence.withContext(SAMPLE_CONTEXT).getEvaluation("flags/whatever", DEFAULT_VALUE);
+
+    assertThat(evaluationDetails.getValue()).isEqualTo(DEFAULT_VALUE);
+    assertThat(evaluationDetails.getErrorType().get()).isEqualTo(NETWORK_ERROR);
+    assertThat(evaluationDetails.getReason()).isEqualTo("ERROR");
+    assertThat(evaluationDetails.getErrorMessage().get())
+        .isEqualTo("io.grpc.StatusRuntimeException: UNAUTHENTICATED");
+    assertThat(evaluationDetails.getVariant()).isEmpty();
+  }
+
+  @Test
+  public void lackOfAssignment() {
+
+    mockResolve(
+        (request, streamObserver) -> {
+          streamObserver.onNext(
+              ResolveFlagsResponse.newBuilder()
+                  .addResolvedFlags(ResolvedFlag.newBuilder().setFlag("flags/whatever").build())
+                  .build());
+          streamObserver.onCompleted();
+        });
+
+    final FlagEvaluation<String> evaluationDetails =
+        confidence.withContext(SAMPLE_CONTEXT).getEvaluation("whatever", DEFAULT_VALUE);
+
+    assertThat(evaluationDetails.getValue()).isEqualTo(DEFAULT_VALUE);
+    assertThat(evaluationDetails.getErrorType()).isEmpty();
+    assertThat(evaluationDetails.getErrorMessage()).isEmpty();
+    assertThat(evaluationDetails.getReason()).startsWith("RESOLVE_REASON_UNSPECIFIED");
+    assertThat(evaluationDetails.getVariant()).isEmpty();
+  }
+
+  @Test
+  public void regularResolve() {
+
+    mockResolve(
+        (ResolveFlagsRequest, streamObserver) -> {
+          assertThat(ResolveFlagsRequest.getFlags(0)).isEqualTo("flags/flag");
+
+          assertThat(ResolveFlagsRequest.getEvaluationContext())
+              .isEqualTo(
+                  Structs.of(
+                      "my-targeting-key", Values.of("the-target-id"), "my-key", Values.of(true)));
+
+          streamObserver.onNext(generateSampleResponse(Collections.emptyList()));
+          streamObserver.onCompleted();
+        });
+
+    final FlagEvaluation<ConfidenceValue.Struct> evaluationDetails =
+        confidence.withContext(SAMPLE_CONTEXT).getEvaluation("flag", ConfidenceValue.Struct.EMPTY);
+
+    assertThat(evaluationDetails.getErrorType()).isEmpty();
+    assertThat(evaluationDetails.getVariant()).isEqualTo("flags/flag/variants/var-A");
+    assertThat(evaluationDetails.getErrorMessage()).isEmpty();
+    // TODO fixup!
+    assertThat(evaluationDetails.getValue())
+        .isEqualTo(
+            ConfidenceValue.of(
+                Map.of(
+                    "prop-A",
+                    ConfidenceValue.of(false),
+                    "prop-B",
+                    ConfidenceValue.of(
+                        Map.of(
+                            "prop-C",
+                            ConfidenceValue.of("str-val"),
+                            "prop-D",
+                            ConfidenceValue.of(5.3))),
+                    "prop-E",
+                    ConfidenceValue.of(50),
+                    "prop-F",
+                    ConfidenceValue.of(List.of(ConfidenceValue.of("a"), ConfidenceValue.of("b"))),
+                    "prop-G",
+                    ConfidenceValue.of(
+                        Map.of(
+                            "prop-H", ConfidenceValue.NULL_VALUE,
+                            "prop-I", ConfidenceValue.NULL_VALUE)))));
+  }
+
+  @Test
+  public void regularResolveWithoutTargetingKey() {
+
+    mockResolve(
+        (ResolveFlagsRequest, streamObserver) -> {
+          assertThat(ResolveFlagsRequest.getFlags(0)).isEqualTo("flags/flag");
+
+          assertThat(ResolveFlagsRequest.getEvaluationContext())
+              .isEqualTo(Structs.of("my-key", Values.of(true)));
+
+          streamObserver.onNext(generateSampleResponse(Collections.emptyList()));
+          streamObserver.onCompleted();
+        });
+
+    final FlagEvaluation<ConfidenceValue> evaluationDetails =
+        confidence
+            .withContext(SAMPLE_CONTEXT_WITHOUT_TARGETING_KEY)
+            .getEvaluation("flag", ConfidenceValue.Struct.EMPTY);
+
+    assertThat(evaluationDetails.getErrorType()).isEmpty();
+    assertThat(evaluationDetails.getVariant()).isEqualTo("flags/flag/variants/var-A");
+    assertThat(evaluationDetails.getErrorMessage()).isEmpty();
+    assertThat(evaluationDetails.getValue())
+        .isEqualTo(
+            ConfidenceValue.of(
+                Map.of(
+                    "prop-A",
+                    ConfidenceValue.of(false),
+                    "prop-B",
+                    ConfidenceValue.of(
+                        Map.of(
+                            "prop-C",
+                            ConfidenceValue.of("str-val"),
+                            "prop-D",
+                            ConfidenceValue.of(5.3))),
+                    "prop-E",
+                    ConfidenceValue.of(50),
+                    "prop-F",
+                    ConfidenceValue.of(List.of(ConfidenceValue.of("a"), ConfidenceValue.of("b"))),
+                    "prop-G",
+                    ConfidenceValue.of(
+                        Map.of(
+                            "prop-H", ConfidenceValue.NULL_VALUE,
+                            "prop-I", ConfidenceValue.NULL_VALUE)))));
+  }
+
+  @Test
+  public void regularResolveWithPath() {
+
+    mockSampleResponse();
+
+    // 1-element path to non-structure value
+    final FlagEvaluation<Boolean> evaluationDetails =
+        confidence.withContext(SAMPLE_CONTEXT).getEvaluation("flag.prop-A", false);
+
+    assertThat(evaluationDetails.getErrorType()).isEmpty();
+    assertThat(evaluationDetails.getVariant()).isEqualTo("flags/flag/variants/var-A");
+    assertThat(evaluationDetails.getErrorMessage()).isEmpty();
+    assertThat(evaluationDetails.getValue().booleanValue()).isEqualTo(false);
+
+    // 1-element path to structure
+    final FlagEvaluation<ConfidenceValue.Struct> evaluationDetails2 =
+        confidence
+            .withContext(SAMPLE_CONTEXT)
+            .getEvaluation("flag.prop-B", ConfidenceValue.Struct.EMPTY);
+    assertThat(evaluationDetails2.getErrorType()).isEmpty();
+    assertThat(evaluationDetails2.getVariant()).isEqualTo("flags/flag/variants/var-A");
+    assertThat(evaluationDetails2.getErrorMessage()).isEmpty();
+    assertThat(evaluationDetails2.getValue())
+        .isEqualTo(
+            ConfidenceValue.of(
+                Map.of(
+                    "prop-C", ConfidenceValue.of("str-val"), "prop-D", ConfidenceValue.of(5.3))));
+
+    // 2-element path to non-structure
+    final FlagEvaluation<String> evaluationDetails3 =
+        confidence.withContext(SAMPLE_CONTEXT).getEvaluation("flag.prop-B.prop-C", DEFAULT_VALUE);
+    assertThat(evaluationDetails3.getErrorType()).isEmpty();
+    assertThat(evaluationDetails3.getVariant()).isEqualTo("flags/flag/variants/var-A");
+    assertThat(evaluationDetails3.getErrorMessage()).isEmpty();
+    assertThat(evaluationDetails3.getValue()).isEqualTo("str-val");
+
+    // 1-element path to null value, returns default
+    final FlagEvaluation<String> evaluationDetails4 =
+        confidence.withContext(SAMPLE_CONTEXT).getEvaluation("flag.prop-G.prop-H", DEFAULT_VALUE);
+    assertThat(evaluationDetails4.getErrorType()).isEmpty();
+    assertThat(evaluationDetails4.getVariant()).isEqualTo("flags/flag/variants/var-A");
+    assertThat(evaluationDetails4.getErrorMessage()).isEmpty();
+    assertThat(evaluationDetails4.getValue()).isEqualTo(DEFAULT_VALUE);
+
+    // derive field on non-structure
+    final FlagEvaluation<String> evaluationDetails5 =
+        confidence
+            .withContext(SAMPLE_CONTEXT)
+            .getEvaluation("flag.prop-A.not-exist", DEFAULT_VALUE);
+    assertThat(evaluationDetails5.getErrorType().get()).isEqualTo(ErrorType.INTERNAL_ERROR);
+    assertThat(evaluationDetails5.getVariant()).isEmpty();
+    assertThat(evaluationDetails5.getReason()).isEqualTo("ERROR");
+    assertThat(evaluationDetails5.getErrorMessage().get()).isEqualTo("Not a StructValue");
+    assertThat(evaluationDetails5.getValue()).isEqualTo(DEFAULT_VALUE);
+
+    // non-existing field on structure
+    final FlagEvaluation<String> evaluationDetails6 =
+        confidence.withContext(SAMPLE_CONTEXT).getEvaluation("flag.not-exist", DEFAULT_VALUE);
+    assertThat(evaluationDetails6.getErrorType().get()).isEqualTo(ErrorType.INVALID_VALUE_PATH);
+    assertThat(evaluationDetails6.getVariant()).isEmpty();
+    assertThat(evaluationDetails6.getReason()).isEqualTo("ERROR");
+    assertThat(evaluationDetails6.getErrorMessage().get())
+        .isEqualTo(
+            "Illegal attempt to derive non-existing field 'not-exist' on structure value "
+                + "'{prop-B={prop-C=str-val, prop-D=5.3}, prop-E=50, prop-G={prop-I=NULL, prop-H=NULL}, "
+                + "prop-F=[[a, b]], prop-A=false}'");
+    assertThat(evaluationDetails6.getValue()).isEqualTo(DEFAULT_VALUE);
+
+    // malformed path without flag name
+    final FlagEvaluation<String> evaluationDetails7 =
+        confidence.withContext(SAMPLE_CONTEXT).getEvaluation("...", DEFAULT_VALUE);
+    assertThat(evaluationDetails7.getErrorType().get()).isEqualTo(ErrorType.INVALID_VALUE_PATH);
+    assertThat(evaluationDetails7.getVariant()).isEmpty();
+    assertThat(evaluationDetails7.getReason()).isEqualTo("ERROR");
+    assertThat(evaluationDetails7.getErrorMessage().get()).isEqualTo("Illegal path string '...'");
+    assertThat(evaluationDetails7.getValue()).isEqualTo(DEFAULT_VALUE);
+  }
+
+  @Test
+  public void booleanResolve() {
+    mockSampleResponse();
+
+    final FlagEvaluation<Boolean> evaluationDetails =
+        confidence.withContext(SAMPLE_CONTEXT).getEvaluation("flag.prop-A", true);
+
+    assertThat(evaluationDetails.getValue()).isFalse();
+    assertThat(evaluationDetails.getVariant()).isEqualTo("flags/flag/variants/var-A");
+    assertThat(evaluationDetails.getErrorMessage()).isEmpty();
+    assertThat(evaluationDetails.getErrorType()).isEmpty();
+  }
+
+  @Test
+  public void stringResolve() {
+    mockSampleResponse();
+
+    final FlagEvaluation<String> evaluationDetails =
+        confidence.withContext(SAMPLE_CONTEXT).getEvaluation("flag.prop-B.prop-C", "default");
+
+    assertThat(evaluationDetails.getValue()).isEqualTo("str-val");
+    assertThat(evaluationDetails.getVariant()).isEqualTo("flags/flag/variants/var-A");
+    assertThat(evaluationDetails.getErrorMessage()).isEmpty();
+    assertThat(evaluationDetails.getErrorType()).isEmpty();
+  }
+
+  @Test
+  public void integerResolve() {
+    mockSampleResponse();
+
+    final FlagEvaluation<Integer> evaluationDetails =
+        confidence.withContext(SAMPLE_CONTEXT).getEvaluation("flag.prop-E", 1000);
+
+    assertThat(evaluationDetails.getValue()).isEqualTo(50);
+    assertThat(evaluationDetails.getVariant()).isEqualTo("flags/flag/variants/var-A");
+    assertThat(evaluationDetails.getErrorMessage()).isEmpty();
+    assertThat(evaluationDetails.getErrorType()).isEmpty();
+  }
+
+  @Test
+  public void doubleResolve() {
+    mockSampleResponse();
+
+    final FlagEvaluation<Double> evaluationDetails =
+        confidence.withContext(SAMPLE_CONTEXT).getEvaluation("flag.prop-B.prop-D", 10.5);
+
+    assertThat(evaluationDetails.getValue()).isEqualTo(5.3);
+    assertThat(evaluationDetails.getVariant()).isEqualTo("flags/flag/variants/var-A");
+    assertThat(evaluationDetails.getErrorMessage()).isEmpty();
+    assertThat(evaluationDetails.getErrorType()).isEmpty();
+  }
+
+  @Test
+  public void longValueInIntegerSchemaResolveShouldFail() {
+    mockSampleResponse(
+        Collections.singletonList(
+            new ValueSchemaHolder(
+                "prop-X",
+                Values.of(Integer.MAX_VALUE + 1L),
+                FlagSchema.SchemaTypeCase.INT_SCHEMA)));
+
+    final FlagEvaluation<Integer> evaluationDetails =
+        confidence.withContext(SAMPLE_CONTEXT).getEvaluation("flag.prop-X", 10);
+
+    assertThat(evaluationDetails.getValue()).isEqualTo(10);
+    assertThat(evaluationDetails.getVariant()).isEmpty();
+    assertThat(evaluationDetails.getErrorMessage().get())
+        .isEqualTo(
+            "Mismatch between schema and value: 2.147483648E9 should be an int, but it is a double/long");
+    assertThat(evaluationDetails.getErrorType().get()).isEqualTo(ErrorType.INTERNAL_ERROR);
+  }
+
+  @Test
+  public void castingWithWrongType() {
+    mockSampleResponse();
+
+    final FlagEvaluation<Boolean> evaluationDetails =
+        confidence.withContext(SAMPLE_CONTEXT).getEvaluation("flag.prop-B.prop-C", true);
+    assertThat(evaluationDetails.getValue()).isTrue();
+    assertThat(evaluationDetails.getVariant()).isEmpty();
+    assertThat(evaluationDetails.getErrorMessage().get())
+        .isEqualTo(
+            "Default type class java.lang.Boolean, but value of type class "
+                + "com.spotify.confidence.ConfidenceValue$StringValue");
+    assertThat(evaluationDetails.getErrorType().get()).isEqualTo(ErrorType.INVALID_VALUE_TYPE);
+  }
+
+  @Test
+  public void resolvesContainHeaderWithTelemetryData() {
+    mockSampleResponse();
+
+    confidence.withContext(SAMPLE_CONTEXT).getEvaluation("flag.prop-E", 1000);
+
+    final Monitoring telemetrySnapshot = telemetry.peekSnapshot();
+    final List<LibraryTraces> libraryTracesList = telemetrySnapshot.getLibraryTracesList();
+    assertThat(libraryTracesList).hasSize(1);
+    final LibraryTraces traces = libraryTracesList.get(0);
+    assertThat(traces.getLibrary()).isEqualTo(LibraryTraces.Library.LIBRARY_CONFIDENCE);
+    assertThat(traces.getTracesList()).hasSize(1);
+    final LibraryTraces.Trace trace = traces.getTraces(0);
+    assertThat(trace.getId()).isEqualTo(LibraryTraces.TraceId.TRACE_ID_RESOLVE_LATENCY);
+    assertThat(trace.getMillisecondDuration()).isNotNegative();
+
+    confidence.withContext(SAMPLE_CONTEXT).getEvaluation("flag.prop-Y", 1000);
+
+    // verify that the grpc request contains telemetry data in the header
+    final Metadata storedHeaders = telemetryInterceptor.getStoredHeaders();
+    assertThat(storedHeaders.containsKey(TelemetryClientInterceptor.HEADER_KEY)).isTrue();
+  }
+
+  //////
+  // Utility
+  //////
+
+  private void mockResolve(
+      BiConsumer<ResolveFlagsRequest, StreamObserver<ResolveFlagsResponse>> impl) {
+    doAnswer(
+            invocation -> {
+              final ResolveFlagsRequest ResolveFlagsRequest = invocation.getArgument(0);
+              final StreamObserver<ResolveFlagsResponse> streamObserver = invocation.getArgument(1);
+
+              impl.accept(ResolveFlagsRequest, streamObserver);
+              return null;
+            })
+        .when(serviceImpl)
+        .resolveFlags(any(), any());
+  }
+
+  private void mockSampleResponse() {
+    mockSampleResponse(Collections.emptyList());
+  }
+
+  private void mockSampleResponse(List<ValueSchemaHolder> additionalProps) {
+    mockResolve(
+        (resolveFlagRequest, streamObserver) -> {
+          assertThat(resolveFlagRequest.getFlags(0)).isEqualTo("flags/flag");
+          streamObserver.onNext(generateSampleResponse(additionalProps));
+          streamObserver.onCompleted();
+        });
+  }
+}

--- a/sdk-java/src/test/java/com/spotify/confidence/telemetry/FakeTelemetryClientInterceptor.java
+++ b/sdk-java/src/test/java/com/spotify/confidence/telemetry/FakeTelemetryClientInterceptor.java
@@ -1,0 +1,29 @@
+package com.spotify.confidence.telemetry;
+
+import io.grpc.*;
+
+public class FakeTelemetryClientInterceptor extends TelemetryClientInterceptor {
+
+  private Metadata storedHeaders;
+
+  public FakeTelemetryClientInterceptor(Telemetry telemetry) {
+    super(telemetry);
+  }
+
+  @Override
+  public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+      MethodDescriptor<ReqT, RespT> method, CallOptions callOptions, Channel next) {
+    return new ForwardingClientCall.SimpleForwardingClientCall<ReqT, RespT>(
+        super.interceptCall(method, callOptions, next)) {
+      @Override
+      public void start(Listener<RespT> responseListener, Metadata headers) {
+        storedHeaders = headers;
+        super.start(responseListener, headers);
+      }
+    };
+  }
+
+  public Metadata getStoredHeaders() {
+    return storedHeaders;
+  }
+}

--- a/sdk-java/src/test/java/com/spotify/confidence/telemetry/FakeTelemetryClientInterceptor.java
+++ b/sdk-java/src/test/java/com/spotify/confidence/telemetry/FakeTelemetryClientInterceptor.java
@@ -1,12 +1,13 @@
 package com.spotify.confidence.telemetry;
 
 import io.grpc.*;
+import javax.annotation.Nullable;
 
 public class FakeTelemetryClientInterceptor extends TelemetryClientInterceptor {
 
   private Metadata storedHeaders;
 
-  public FakeTelemetryClientInterceptor(Telemetry telemetry) {
+  public FakeTelemetryClientInterceptor(@Nullable Telemetry telemetry) {
     super(telemetry);
   }
 


### PR DESCRIPTION
The idea with this PR is to add a header with information about how long each resolve took. 
It's defining a proto message and encodes the telemetry data in this message as a base64 encoded byte array putting it to the `X-CONFIDENCE-TELEMETRY` header.