### PR TITLE
refactor: align on a single way to define isProvider

### DIFF
--- a/openfeature-provider/src/main/java/com/spotify/confidence/ConfidenceFeatureProvider.java
+++ b/openfeature-provider/src/main/java/com/spotify/confidence/ConfidenceFeatureProvider.java
@@ -163,7 +163,7 @@ public class ConfidenceFeatureProvider implements FeatureProvider {
                   Map.of(
                       OPEN_FEATURE_RESOLVE_CONTEXT_KEY,
                       ConfidenceValue.Struct.fromProto(evaluationContext)))
-              .resolveFlags(requestFlagName, true)
+              .resolveFlags(requestFlagName)
               .get();
 
       if (resolveFlagResponse.getResolvedFlagsList().isEmpty()) {

--- a/openfeature-provider/src/test/java/com/spotify/confidence/ResolverClientTestUtils.java
+++ b/openfeature-provider/src/test/java/com/spotify/confidence/ResolverClientTestUtils.java
@@ -24,7 +24,7 @@ public class ResolverClientTestUtils {
 
     @Override
     public CompletableFuture<ResolveFlagsResponse> resolveFlags(
-        String flag, ConfidenceValue.Struct context, Boolean isProvider) {
+        String flag, ConfidenceValue.Struct context) {
       resolves.put(flag, context);
       return CompletableFuture.completedFuture(response);
     }

--- a/sdk-java/src/main/java/com/spotify/confidence/Confidence.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/Confidence.java
@@ -123,7 +123,7 @@ public abstract class Confidence implements EventSender, Closeable {
     try {
       final FlagPath flagPath = getPath(key);
       final String requestFlagName = "flags/" + flagPath.getFlag();
-      final ResolveFlagsResponse response = resolveFlags(requestFlagName, false).get();
+      final ResolveFlagsResponse response = resolveFlags(requestFlagName).get();
       if (response.getResolvedFlagsList().isEmpty()) {
         final String errorMessage =
             String.format("No active flag '%s' was found", flagPath.getFlag());
@@ -188,8 +188,8 @@ public abstract class Confidence implements EventSender, Closeable {
     }
   }
 
-  CompletableFuture<ResolveFlagsResponse> resolveFlags(String flagName, Boolean isProvider) {
-    return client().resolveFlags(flagName, getContext(), isProvider);
+  CompletableFuture<ResolveFlagsResponse> resolveFlags(String flagName) {
+    return client().resolveFlags(flagName, getContext());
   }
 
   @VisibleForTesting
@@ -232,8 +232,8 @@ public abstract class Confidence implements EventSender, Closeable {
 
     @Override
     public CompletableFuture<ResolveFlagsResponse> resolveFlags(
-        String flag, ConfidenceValue.Struct context, Boolean isProvider) {
-      return flagResolverClient.resolveFlags(flag, context, isProvider);
+        String flag, ConfidenceValue.Struct context) {
+      return flagResolverClient.resolveFlags(flag, context);
     }
 
     @Override

--- a/sdk-java/src/main/java/com/spotify/confidence/FlagResolverClient.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/FlagResolverClient.java
@@ -5,6 +5,5 @@ import java.io.Closeable;
 import java.util.concurrent.CompletableFuture;
 
 interface FlagResolverClient extends Closeable {
-  CompletableFuture<ResolveFlagsResponse> resolveFlags(
-      String flag, ConfidenceValue.Struct context, Boolean isProvider);
+  CompletableFuture<ResolveFlagsResponse> resolveFlags(String flag, ConfidenceValue.Struct context);
 }

--- a/sdk-java/src/main/java/com/spotify/confidence/FlagResolverClientImpl.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/FlagResolverClientImpl.java
@@ -13,10 +13,12 @@ class FlagResolverClientImpl implements FlagResolverClient {
   public static final String OPEN_FEATURE_RESOLVE_CONTEXT_KEY = "open-feature";
   private final FlagResolver grpcFlagResolver;
   private final @Nullable Telemetry telemetry;
+  private final boolean isProvider;
 
   public FlagResolverClientImpl(FlagResolver grpcFlagResolver, @Nullable Telemetry telemetry) {
     this.grpcFlagResolver = grpcFlagResolver;
     this.telemetry = telemetry;
+    this.isProvider = telemetry != null && telemetry.isProvider();
   }
 
   public FlagResolverClientImpl(FlagResolver grpcFlagResolver) {
@@ -24,7 +26,7 @@ class FlagResolverClientImpl implements FlagResolverClient {
   }
 
   public CompletableFuture<ResolveFlagsResponse> resolveFlags(
-      String flagName, ConfidenceValue.Struct context, Boolean isProvider) {
+      String flagName, ConfidenceValue.Struct context) {
     final Instant start = Instant.now();
 
     final Struct.Builder evaluationContextBuilder = context.toProto().getStructValue().toBuilder();

--- a/sdk-java/src/main/java/com/spotify/confidence/telemetry/Telemetry.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/telemetry/Telemetry.java
@@ -49,4 +49,8 @@ public class Telemetry {
   private void clear() {
     latencyTraces.clear();
   }
+
+  public boolean isProvider() {
+    return isProvider;
+  }
 }

--- a/sdk-java/src/test/java/com/spotify/confidence/ConfidenceResourceManagementTest.java
+++ b/sdk-java/src/test/java/com/spotify/confidence/ConfidenceResourceManagementTest.java
@@ -25,7 +25,7 @@ public class ConfidenceResourceManagementTest {
   public void testCloseChildShouldThrowFromResolveFlags() throws IOException {
     final Confidence child = root.withContext(Map.of("child-key", ConfidenceValue.of("child")));
     child.close();
-    assertThrows(IllegalStateException.class, () -> child.resolveFlags("test", false).get());
+    assertThrows(IllegalStateException.class, () -> child.resolveFlags("test").get());
   }
 
   @Test
@@ -48,7 +48,7 @@ public class ConfidenceResourceManagementTest {
       throws IOException, ExecutionException, InterruptedException {
     final Confidence child = root.withContext(Map.of("child-key", ConfidenceValue.of("child")));
     child.close();
-    root.resolveFlags("test", false).get();
+    root.resolveFlags("test").get();
     root.track("test", ConfidenceValue.of(Map.of("messageKey", ConfidenceValue.of("parent"))));
   }
 
@@ -56,8 +56,8 @@ public class ConfidenceResourceManagementTest {
   public void testCloseParentShouldAffectChild() throws IOException {
     final Confidence child = root.withContext(Map.of("child-key", ConfidenceValue.of("child")));
     root.close();
-    assertThrows(IllegalStateException.class, () -> child.resolveFlags("test", false).get());
-    assertThrows(IllegalStateException.class, () -> root.resolveFlags("test", false).get());
+    assertThrows(IllegalStateException.class, () -> child.resolveFlags("test").get());
+    assertThrows(IllegalStateException.class, () -> root.resolveFlags("test").get());
     assertTrue(fakeEngine.closed);
     assertTrue(fakeFlagResolverClient.closed);
   }

--- a/sdk-java/src/test/java/com/spotify/confidence/ConfidenceTest.java
+++ b/sdk-java/src/test/java/com/spotify/confidence/ConfidenceTest.java
@@ -261,8 +261,7 @@ final class ConfidenceTest {
   public static class FailingFlagResolverClient implements FlagResolverClient {
 
     @Override
-    public CompletableFuture<ResolveFlagsResponse> resolveFlags(
-        String flag, Struct context, Boolean isProvider) {
+    public CompletableFuture<ResolveFlagsResponse> resolveFlags(String flag, Struct context) {
       throw new RuntimeException("Crashing while performing network call");
     }
 

--- a/sdk-java/src/test/java/com/spotify/confidence/ResolverClientTestUtils.java
+++ b/sdk-java/src/test/java/com/spotify/confidence/ResolverClientTestUtils.java
@@ -24,7 +24,7 @@ public class ResolverClientTestUtils {
 
     @Override
     public CompletableFuture<ResolveFlagsResponse> resolveFlags(
-        String flag, ConfidenceValue.Struct context, Boolean isProvider) {
+        String flag, ConfidenceValue.Struct context) {
       resolves.put(flag, context);
       return CompletableFuture.completedFuture(response);
     }


### PR DESCRIPTION
Followup on https://github.com/spotify/confidence-sdk-java/pull/158 to align the two different ways to define the `isProvider` between the two instrumentation efforts.