### PR TITLE
fix: change how we log resolve tester hints

### DIFF
--- a/sdk-java/pom.xml
+++ b/sdk-java/pom.xml
@@ -11,12 +11,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java-util</artifactId>
-      <version>${protobuf.version}</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>io.grpc</groupId>
       <artifactId>grpc-protobuf</artifactId>
       <version>${grpc.version}</version>
@@ -41,6 +35,12 @@
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-common-protos</artifactId>
       <version>${common.protos.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.4.14</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/sdk-java/pom.xml
+++ b/sdk-java/pom.xml
@@ -28,6 +28,11 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java-util</artifactId>
+      <version>${protobuf.version}</version>
+    </dependency>
+    <dependency>
       <groupId>dev.failsafe</groupId>
       <artifactId>failsafe</artifactId>
       <version>3.3.2</version>

--- a/sdk-java/src/main/java/com/spotify/confidence/Confidence.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/Confidence.java
@@ -201,7 +201,6 @@ public abstract class Confidence implements FlagEvaluator, EventSender, Closeabl
     final String clientKey = client().clientSecret;
     final String flag = resolvedFlag.getFlag();
     try {
-
       final ResolveTesterLogging resolveTesterLogging =
           ResolveTesterLogging.newBuilder()
               .setClientKey(clientKey)

--- a/sdk-java/src/main/proto/confidence/internal.proto
+++ b/sdk-java/src/main/proto/confidence/internal.proto
@@ -1,0 +1,14 @@
+syntax = "proto3";
+
+import "google/protobuf/struct.proto";
+
+package confidence.internal.v1;
+option java_package = "com.spotify.internal.v1";
+option java_multiple_files = true;
+option java_outer_classname = "SdkLogging";
+
+message ResolveTesterLogging {
+    string client_key = 1;
+    string flag = 2;
+    google.protobuf.Value context = 3;
+}


### PR DESCRIPTION
Resolver hint logs will now contain a base64 encoded string which can be pasted in the Confidence tools to support that we don't necessarily know the URL the user would want to use.