### PR TITLE
feat: allow configuring grpc deadline

### DIFF
--- a/openfeature-provider/src/test/java/com/spotify/confidence/FeatureProviderTest.java
+++ b/openfeature-provider/src/test/java/com/spotify/confidence/FeatureProviderTest.java
@@ -76,7 +76,7 @@ final class FeatureProviderTest {
         new TelemetryClientInterceptor(telemetry);
     final FlagResolverClientImpl flagResolver =
         new FlagResolverClientImpl(
-            new GrpcFlagResolver("fake-secret", channel, telemetryInterceptor), telemetry);
+            new GrpcFlagResolver("fake-secret", channel, telemetryInterceptor, 1_000), telemetry);
     final Confidence confidence = Confidence.create(fakeEventSender, flagResolver, "clientKey");
     final FeatureProvider featureProvider = new ConfidenceFeatureProvider(confidence);
 

--- a/sdk-java/src/main/java/com/spotify/confidence/EventSenderEngineImpl.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/EventSenderEngineImpl.java
@@ -64,10 +64,11 @@ class EventSenderEngineImpl implements EventSenderEngine {
     pollingThread.start();
   }
 
-  EventSenderEngineImpl(String clientSecret, ManagedChannel channel, Clock clock) {
+  EventSenderEngineImpl(
+      String clientSecret, ManagedChannel channel, Clock clock, int deadlineMillis) {
     this(
         DEFAULT_BATCH_SIZE,
-        new GrpcEventUploader(clientSecret, clock, channel),
+        new GrpcEventUploader(clientSecret, clock, channel, deadlineMillis),
         clock,
         DEFAULT_MAX_FLUSH_INTERVAL,
         DEFAULT_MAX_MEMORY_CONSUMPTION);

--- a/sdk-java/src/test/java/com/spotify/confidence/ConfidenceIntegrationTest.java
+++ b/sdk-java/src/test/java/com/spotify/confidence/ConfidenceIntegrationTest.java
@@ -78,7 +78,7 @@ final class ConfidenceIntegrationTest {
     telemetryInterceptor = new FakeTelemetryClientInterceptor(telemetry);
     final FlagResolverClientImpl flagResolver =
         new FlagResolverClientImpl(
-            new GrpcFlagResolver("fake-secret", channel, telemetryInterceptor), telemetry);
+            new GrpcFlagResolver("fake-secret", channel, telemetryInterceptor, 1_000), telemetry);
     confidence = Confidence.create(fakeEventSender, flagResolver, "");
   }
 
@@ -477,7 +477,7 @@ final class ConfidenceIntegrationTest {
         new FakeTelemetryClientInterceptor(null);
     final FlagResolverClientImpl flagResolver =
         new FlagResolverClientImpl(
-            new GrpcFlagResolver("fake-secret", channel, nullTelemetryInterceptor));
+            new GrpcFlagResolver("fake-secret", channel, nullTelemetryInterceptor, 1_000));
     confidence = Confidence.create(fakeEventSender, flagResolver, "clientKey");
 
     mockSampleResponse();

--- a/sdk-java/src/test/java/com/spotify/confidence/GrpcEventUploaderTest.java
+++ b/sdk-java/src/test/java/com/spotify/confidence/GrpcEventUploaderTest.java
@@ -54,7 +54,7 @@ class GrpcEventUploaderTest {
     fakeClock.setCurrentTimeSeconds(1337);
 
     // Create a client that uses the channel
-    uploader = new GrpcEventUploader("my-client-secret", fakeClock, channel);
+    uploader = new GrpcEventUploader("my-client-secret", fakeClock, channel, 5_000);
   }
 
   @AfterEach


### PR DESCRIPTION
This PR brings the functionality to set the GRPC deadline for the resolve call and the track event uploads.
It defaults to the same values that were hard coded previously.