### PR TITLE
fix: Fix maven central connection

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -44,8 +44,8 @@ jobs:
       - name: Deploy with Maven
         run: mvn --batch-mode clean deploy
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME_2 }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN_2 }}
           GPG_PASS: ${{ secrets.SIGN_KEY_PASS }} # Password chosen when creating the GPG key
 
   release-deploy:
@@ -72,6 +72,6 @@ jobs:
       - name: Deploy with Maven
         run: mvn --batch-mode clean deploy
         env:
-          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
+          MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME_2 }}
+          MAVEN_PASSWORD: ${{ secrets.OSSRH_TOKEN_2 }}
           GPG_PASS: ${{ secrets.SIGN_KEY_PASS }} # Password chosen when creating the GPG key

--- a/pom.xml
+++ b/pom.xml
@@ -10,11 +10,11 @@
   <distributionManagement>
     <snapshotRepository>
       <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <url>https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots</url>
     </snapshotRepository>
     <repository>
       <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+      <url>https://ossrh-staging-api.central.sonatype.com/service/local/staging/deploy/maven2/</url>
     </repository>
   </distributionManagement>
 


### PR DESCRIPTION
The OSSRH system we used in the past to publish to Maven has shut down on June 30, 2025 ([ref](https://central.sonatype.org/pages/ossrh-eol/)). This is updating the endpoints to the new one (as recommended [here](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/#configuration)) and using newly created token credentials