### PR TITLE
chore: Add name to submodule poms

### DIFF
--- a/openfeature-provider/pom.xml
+++ b/openfeature-provider/pom.xml
@@ -9,6 +9,62 @@
 
   <artifactId>openfeature-provider</artifactId>
 
+  <name>Confidence SDK - OpenFeature Provider</name>
+  <organization>
+      <name>com.spotify</name>
+      <url>https://github.com/spotify</url>
+  </organization>
+
+  <issueManagement>
+      <system>GitHub</system>
+      <url>https://github.com/spotify/confidence-sdk-java/issues</url>
+  </issueManagement>
+
+  <licenses>
+      <license>
+          <name>Apache License 2.0</name>
+          <url>https://github.com/spotify/confidence-sdk-java/blob/main/LICENSE</url>
+          <distribution>repo</distribution>
+      </license>
+  </licenses>
+
+  <scm>
+      <url>https://github.com/spotify/confidence-sdk-java</url>
+      <connection>
+          scm:git:git@github.com:spotify/confidence-sdk-java.git
+      </connection>
+      <developerConnection>
+          scm:git:git@github.com:spotify/confidence-sdk-java.git
+      </developerConnection>
+  </scm>
+  <developers>
+      <developer>
+        <id>fdema</id>
+        <email>fdema@spotify.com</email>
+        <name>Fabrizio Demaria</name>
+      </developer>
+      <developer>
+          <id>nicklasl</id>
+          <email>nicklasl@spotify.com</email>
+          <name>Nicklas Lundin</name>
+      </developer>
+      <developer>
+          <id>DennisPersson</id>
+          <email>dennisp@spotify.com</email>
+          <name>Dennis Persson</name>
+      </developer>
+      <developer>
+          <id>mfranberg</id>
+          <email>mfranberg@spotify.com</email>
+          <name>Mattias Frånberg</name>
+      </developer>
+      <developer>
+        <id>andreas-karlsson</id>
+        <email>andreask@spotify.com</email>
+        <name>Andreas Karlsson</name>
+      </developer>
+  </developers>
+
   <dependencies>
     <!-- x-release-please-start-version -->
     <dependency>

--- a/sdk-java/pom.xml
+++ b/sdk-java/pom.xml
@@ -9,6 +9,62 @@
 
   <artifactId>sdk-java</artifactId>
 
+  <name>Confidence SDK - Native</name>
+  <organization>
+      <name>com.spotify</name>
+      <url>https://github.com/spotify</url>
+  </organization>
+
+  <issueManagement>
+      <system>GitHub</system>
+      <url>https://github.com/spotify/confidence-sdk-java/issues</url>
+  </issueManagement>
+
+  <licenses>
+      <license>
+          <name>Apache License 2.0</name>
+          <url>https://github.com/spotify/confidence-sdk-java/blob/main/LICENSE</url>
+          <distribution>repo</distribution>
+      </license>
+  </licenses>
+
+  <scm>
+      <url>https://github.com/spotify/confidence-sdk-java</url>
+      <connection>
+          scm:git:git@github.com:spotify/confidence-sdk-java.git
+      </connection>
+      <developerConnection>
+          scm:git:git@github.com:spotify/confidence-sdk-java.git
+      </developerConnection>
+  </scm>
+  <developers>
+      <developer>
+        <id>fdema</id>
+        <email>fdema@spotify.com</email>
+        <name>Fabrizio Demaria</name>
+      </developer>
+      <developer>
+          <id>nicklasl</id>
+          <email>nicklasl@spotify.com</email>
+          <name>Nicklas Lundin</name>
+      </developer>
+      <developer>
+          <id>DennisPersson</id>
+          <email>dennisp@spotify.com</email>
+          <name>Dennis Persson</name>
+      </developer>
+      <developer>
+          <id>mfranberg</id>
+          <email>mfranberg@spotify.com</email>
+          <name>Mattias Frånberg</name>
+      </developer>
+      <developer>
+        <id>andreas-karlsson</id>
+        <email>andreask@spotify.com</email>
+        <name>Andreas Karlsson</name>
+      </developer>
+  </developers>
+
   <dependencies>
     <dependency>
       <groupId>io.grpc</groupId>


### PR DESCRIPTION
Trying to fix deployment errors from Maven Central:
<img width="1020" alt="Screenshot 2025-07-08 at 15 58 19" src="https://github.com/user-attachments/assets/2aa51292-41e6-48a1-b20c-343e20526961" />

All the metadata just copied from the root pom
