### PR TITLE
build: Fix maven config retrieval

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -452,7 +452,7 @@
       <plugin>
         <groupId>org.sonatype.central</groupId>
         <artifactId>central-publishing-maven-plugin</artifactId>
-        <version>0.8.0</version>
+        <version>0.8.1</version>
         <extensions>true</extensions>
         <configuration>
           <publishingServerId>central</publishingServerId>


### PR DESCRIPTION
Main is currently broken due to:

`Error:  Failed to execute goal org.sonatype.central:central-publishing-maven-plugin:0.8.0:publish (injected-central-publishing) on project confidence-sdk-java: Execution injected-central-publishing of goal org.sonatype.central:central-publishing-maven-plugin:0.8.0:publish failed: Unable to get publisher server properties for server id: central: Cannot invoke "org.apache.maven.settings.Server.clone()" because "server" is null -> [Help 1]`

AI suggests to bump the plugin, as this is a known bug in 0.8.0
