### PR TITLE
build: Remove proto files from JARs

### DIFF
--- a/confidence-proto/pom.xml
+++ b/confidence-proto/pom.xml
@@ -118,6 +118,26 @@
           </annotationProcessorPaths>
         </configuration>
       </plugin>
+      <!-- Exclude proto files from all JARs to prevent conflicts -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <version>3.3.0</version>
+        <configuration>
+          <excludes>
+            <exclude>**/*.proto</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>**/*.proto</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,6 @@
         <directory>src/main/resources</directory>
         <filtering>true</filtering>
       </resource>
-      <resource><directory>src/main/proto</directory></resource>
     </resources>
     <plugins>
       <plugin>


### PR DESCRIPTION
We noticed that the proto files might cause conflicts if the consumer already define similar protos