### PR TITLE
feat: AccountStateProvider based constructor for WASM testing

### DIFF
--- a/openfeature-provider-local/src/main/java/com/spotify/confidence/AccountStateProvider.java
+++ b/openfeature-provider-local/src/main/java/com/spotify/confidence/AccountStateProvider.java
@@ -3,20 +3,21 @@ package com.spotify.confidence;
 /**
  * Functional interface for providing AccountState instances.
  *
- * <p>This interface allows custom implementations to provide AccountState data instead of using the
- * default FlagsAdminStateFetcher. This is useful for scenarios where flag data should be sourced
- * from custom locations or caching mechanisms.
+ * <p>The untyped nature of this interface allows high flexibility for testing, but it's not advised
+ * to be used in production.
  *
- * @since 0.2.4
+ * <p>This can be useful if the provider implementer defines the AccountState proto schema in a
+ * different Java package.
  */
 @FunctionalInterface
 public interface AccountStateProvider {
 
   /**
-   * Provides an AccountState instance.
+   * Provides an AccountState protobuf, from this proto specification: {@link
+   * com.spotify.confidence.shaded.flags.admin.v1.AccountState}
    *
-   * @return the AccountState containing flag configurations and metadata
+   * @return the AccountState protobuf containing flag configurations and metadata
    * @throws RuntimeException if the AccountState cannot be provided
    */
-  AccountState provide();
+  byte[] provide();
 }

--- a/openfeature-provider-local/src/test/java/com/spotify/confidence/ResolveTest.java
+++ b/openfeature-provider-local/src/test/java/com/spotify/confidence/ResolveTest.java
@@ -227,25 +227,4 @@ abstract class ResolveTest extends TestBase {
     assertEquals(
         ResolveReason.RESOLVE_REASON_TARGETING_KEY_ERROR, response.getResolvedFlags(0).getReason());
   }
-
-  @Test
-  public void testAccountStateProviderInterface() {
-    final AccountStateProvider customProvider =
-        () ->
-            new AccountState(
-                new Account(account, Region.EU), flags, segments, bitsets, secrets, "test-etag");
-
-    final AccountState providedState = customProvider.provide();
-
-    assertThat(providedState.account().name()).isEqualTo(account);
-    assertThat(providedState.flags()).containsKey(flag1);
-    assertThat(providedState.segments()).containsKey(segmentA);
-    assertThat(providedState.secrets()).containsKey(secret);
-    assertThat(providedState.stateFileHash()).isEqualTo("test-etag");
-
-    final Flag providedFlag = providedState.flags().get(flag1);
-    assertThat(providedFlag.getName()).isEqualTo(flag1);
-    assertThat(providedFlag.getState()).isEqualTo(Flag.State.ACTIVE);
-    assertThat(providedFlag.getVariantsList()).hasSize(2);
-  }
 }

--- a/openfeature-provider-local/src/test/java/com/spotify/confidence/TestBase.java
+++ b/openfeature-provider-local/src/test/java/com/spotify/confidence/TestBase.java
@@ -7,7 +7,6 @@ import com.google.protobuf.util.Structs;
 import com.google.protobuf.util.Values;
 import com.spotify.confidence.shaded.flags.resolver.v1.ResolveFlagsRequest;
 import com.spotify.confidence.shaded.flags.resolver.v1.ResolveFlagsResponse;
-import com.spotify.confidence.shaded.flags.resolver.v1.Sdk;
 import com.spotify.confidence.shaded.iam.v1.Client;
 import com.spotify.confidence.shaded.iam.v1.ClientCredential;
 import java.util.BitSet;
@@ -44,24 +43,7 @@ public class TestBase {
     final ResolveTokenConverter resolveTokenConverter = new PlainResolveTokenConverter();
     if (isWasm) {
       final var wasmResolverApi =
-          new SwapWasmResolverApi(
-              new FlagLogger() {
-                @Override
-                public void logResolve(
-                    String resolveId,
-                    Struct evaluationContext,
-                    Sdk sdk,
-                    AccountClient accountClient,
-                    List<ResolvedValue> values) {}
-
-                @Override
-                public void logAssigns(
-                    String resolveId,
-                    Sdk sdk,
-                    List<FlagToApply> flagsToApply,
-                    AccountClient accountClient) {}
-              },
-              desiredState.toProto().toByteArray());
+          new SwapWasmResolverApi(new NoopFlagLogger(), desiredState.toProto().toByteArray());
       resolverServiceFactory =
           new LocalResolverServiceFactory(
               wasmResolverApi, resolverState, resolveTokenConverter, mock());

--- a/openfeature-provider-local/src/test/java/com/spotify/confidence/WasmResolveTest.java
+++ b/openfeature-provider-local/src/test/java/com/spotify/confidence/WasmResolveTest.java
@@ -1,7 +1,36 @@
 package com.spotify.confidence;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.spotify.confidence.shaded.flags.resolver.v1.ResolveReason;
+import dev.openfeature.sdk.ImmutableContext;
+import dev.openfeature.sdk.ProviderEvaluation;
+import dev.openfeature.sdk.Value;
+import org.junit.jupiter.api.Test;
+
 public class WasmResolveTest extends ResolveTest {
   public WasmResolveTest() {
     super(true);
+  }
+
+  @Test
+  public void testAccountStateProviderInterface() {
+    final AccountStateProvider customProvider = () -> exampleState.toProto().toByteArray();
+    final OpenFeatureLocalResolveProvider localResolveProvider =
+        new OpenFeatureLocalResolveProvider(customProvider, TestBase.secret.getSecret());
+    final ProviderEvaluation<Value> objectEvaluation =
+        localResolveProvider.getObjectEvaluation(
+            "flag-1", new Value("error"), new ImmutableContext("user1"));
+
+    assertEquals("flags/flag-1/variants/onnn", objectEvaluation.getVariant());
+    assertEquals(ResolveReason.RESOLVE_REASON_MATCH.toString(), objectEvaluation.getReason());
+    assertNull(objectEvaluation.getErrorCode());
+    assertNull(objectEvaluation.getErrorMessage());
+    assertTrue(objectEvaluation.getValue().isStructure());
+    final var structure = objectEvaluation.getValue().asStructure();
+    assertEquals("on", structure.getValue("data").asString());
+    assertTrue(structure.getValue("extra").isNull());
   }
 }


### PR DESCRIPTION
PR driven by the need for a flexible ResolverState injection for the WASM Local Resolver, for internal testing.

I think eventually Confidence should publish the generated classes from their protos, so we can remove the shading and share the types between this Provider and any internal integration we need.