### PR TITLE
Update SDK version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add the OpenFeature provider dependency if you want to use Confidence via the Op
 <dependency>
     <groupId>com.spotify.confidence</groupId>
     <artifactId>openfeature-provider</artifactId>
-    <version>0.2.8</version>
+    <version>0.3.1</version>
 </dependency>
 ```
 <!---x-release-please-end-->


### PR DESCRIPTION
I got an error when copy pasting the maven `dependency` info. 0.2.8 doesn't exist for some reason while 0.3.1 works fine.