### PR TITLE
chore: add @Nonnull annotations to public APIs

### DIFF
--- a/openfeature-provider-local/pom.xml
+++ b/openfeature-provider-local/pom.xml
@@ -42,7 +42,12 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-    
+
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>

--- a/openfeature-provider-local/src/main/java/com/spotify/confidence/AccountStateProvider.java
+++ b/openfeature-provider-local/src/main/java/com/spotify/confidence/AccountStateProvider.java
@@ -1,5 +1,7 @@
 package com.spotify.confidence;
 
+import javax.annotation.Nonnull;
+
 /**
  * Functional interface for providing AccountState instances.
  *
@@ -19,5 +21,6 @@ public interface AccountStateProvider {
    * @return the AccountState protobuf containing flag configurations and metadata
    * @throws RuntimeException if the AccountState cannot be provided
    */
+  @Nonnull
   byte[] provide();
 }

--- a/openfeature-provider-local/src/main/java/com/spotify/confidence/ApiSecret.java
+++ b/openfeature-provider-local/src/main/java/com/spotify/confidence/ApiSecret.java
@@ -1,5 +1,7 @@
 package com.spotify.confidence;
 
+import javax.annotation.Nonnull;
+
 /**
  * API credentials for authenticating with the Confidence service.
  *
@@ -10,4 +12,4 @@ package com.spotify.confidence;
  * @param clientSecret the client secret for your Confidence application
  * @since 0.2.4
  */
-public record ApiSecret(String clientId, String clientSecret) {}
+public record ApiSecret(@Nonnull String clientId, @Nonnull String clientSecret) {}

--- a/openfeature-provider-local/src/main/java/com/spotify/confidence/MaterializationInfo.java
+++ b/openfeature-provider-local/src/main/java/com/spotify/confidence/MaterializationInfo.java
@@ -1,8 +1,8 @@
 package com.spotify.confidence;
 
-import javax.annotation.Nonnull;
 import java.util.Map;
 import java.util.Optional;
+import javax.annotation.Nonnull;
 
 public record MaterializationInfo(
     boolean isUnitInMaterialization, @Nonnull Map<String, String> ruleToVariant) {

--- a/openfeature-provider-local/src/main/java/com/spotify/confidence/MaterializationInfo.java
+++ b/openfeature-provider-local/src/main/java/com/spotify/confidence/MaterializationInfo.java
@@ -1,10 +1,11 @@
 package com.spotify.confidence;
 
+import javax.annotation.Nonnull;
 import java.util.Map;
 import java.util.Optional;
 
 public record MaterializationInfo(
-    boolean isUnitInMaterialization, Map<String, String> ruleToVariant) {
+    boolean isUnitInMaterialization, @Nonnull Map<String, String> ruleToVariant) {
   public Optional<String> getVariantForRule(String rule) {
     return Optional.ofNullable(ruleToVariant.get(rule));
   }

--- a/openfeature-provider-local/src/main/java/com/spotify/confidence/MaterializationRepository.java
+++ b/openfeature-provider-local/src/main/java/com/spotify/confidence/MaterializationRepository.java
@@ -1,8 +1,8 @@
 package com.spotify.confidence;
 
-import javax.annotation.Nonnull;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
+import javax.annotation.Nonnull;
 
 public non-sealed interface MaterializationRepository extends StickyResolveStrategy {
   @Nonnull

--- a/openfeature-provider-local/src/main/java/com/spotify/confidence/MaterializationRepository.java
+++ b/openfeature-provider-local/src/main/java/com/spotify/confidence/MaterializationRepository.java
@@ -6,10 +6,10 @@ import javax.annotation.Nonnull;
 
 public non-sealed interface MaterializationRepository extends StickyResolveStrategy {
   @Nonnull
-  CompletableFuture<@Nonnull Map<String, MaterializationInfo>> loadMaterializedAssignmentsForUnit(
+  CompletableFuture<Map<String, MaterializationInfo>> loadMaterializedAssignmentsForUnit(
       @Nonnull String unit, @Nonnull String materialization);
 
   @Nonnull
   CompletableFuture<Void> storeAssignment(
-      @Nonnull String unit, @Nonnull Map<String, MaterializationInfo> assignments);
+      @Nonnull String unit, Map<String, MaterializationInfo> assignments);
 }

--- a/openfeature-provider-local/src/main/java/com/spotify/confidence/MaterializationRepository.java
+++ b/openfeature-provider-local/src/main/java/com/spotify/confidence/MaterializationRepository.java
@@ -1,12 +1,15 @@
 package com.spotify.confidence;
 
+import javax.annotation.Nonnull;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 public non-sealed interface MaterializationRepository extends StickyResolveStrategy {
-  CompletableFuture<Map<String, MaterializationInfo>> loadMaterializedAssignmentsForUnit(
-      String unit, String materialization);
+  @Nonnull
+  CompletableFuture<@Nonnull Map<String, MaterializationInfo>> loadMaterializedAssignmentsForUnit(
+      @Nonnull String unit, @Nonnull String materialization);
 
+  @Nonnull
   CompletableFuture<Void> storeAssignment(
-      String unit, Map<String, MaterializationInfo> assignments);
+      @Nonnull String unit, @Nonnull Map<String, MaterializationInfo> assignments);
 }

--- a/openfeature-provider-local/src/main/java/com/spotify/confidence/OpenFeatureLocalResolveProvider.java
+++ b/openfeature-provider-local/src/main/java/com/spotify/confidence/OpenFeatureLocalResolveProvider.java
@@ -90,7 +90,8 @@ public class OpenFeatureLocalResolveProvider implements FeatureProvider {
    *     configuration
    * @since 0.2.4
    */
-  public OpenFeatureLocalResolveProvider(@Nonnull ApiSecret apiSecret, @Nonnull String clientSecret) {
+  public OpenFeatureLocalResolveProvider(
+      @Nonnull ApiSecret apiSecret, @Nonnull String clientSecret) {
     this(apiSecret, clientSecret, new RemoteResolverFallback(), new NoRetryStrategy());
   }
 
@@ -111,7 +112,9 @@ public class OpenFeatureLocalResolveProvider implements FeatureProvider {
    * @since 0.2.4
    */
   public OpenFeatureLocalResolveProvider(
-      @Nonnull ApiSecret apiSecret, @Nonnull String clientSecret, @Nonnull StickyResolveStrategy stickyResolveStrategy) {
+      @Nonnull ApiSecret apiSecret,
+      @Nonnull String clientSecret,
+      @Nonnull StickyResolveStrategy stickyResolveStrategy) {
     this(apiSecret, clientSecret, stickyResolveStrategy, new NoRetryStrategy());
   }
 

--- a/openfeature-provider-local/src/main/java/com/spotify/confidence/OpenFeatureLocalResolveProvider.java
+++ b/openfeature-provider-local/src/main/java/com/spotify/confidence/OpenFeatureLocalResolveProvider.java
@@ -17,6 +17,7 @@ import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
+import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 
 /**
@@ -89,7 +90,7 @@ public class OpenFeatureLocalResolveProvider implements FeatureProvider {
    *     configuration
    * @since 0.2.4
    */
-  public OpenFeatureLocalResolveProvider(ApiSecret apiSecret, String clientSecret) {
+  public OpenFeatureLocalResolveProvider(@Nonnull ApiSecret apiSecret, @Nonnull String clientSecret) {
     this(apiSecret, clientSecret, new RemoteResolverFallback(), new NoRetryStrategy());
   }
 
@@ -110,7 +111,7 @@ public class OpenFeatureLocalResolveProvider implements FeatureProvider {
    * @since 0.2.4
    */
   public OpenFeatureLocalResolveProvider(
-      ApiSecret apiSecret, String clientSecret, StickyResolveStrategy stickyResolveStrategy) {
+      @Nonnull ApiSecret apiSecret, @Nonnull String clientSecret, @Nonnull StickyResolveStrategy stickyResolveStrategy) {
     this(apiSecret, clientSecret, stickyResolveStrategy, new NoRetryStrategy());
   }
 
@@ -133,10 +134,10 @@ public class OpenFeatureLocalResolveProvider implements FeatureProvider {
    * @since 0.2.4
    */
   public OpenFeatureLocalResolveProvider(
-      ApiSecret apiSecret,
-      String clientSecret,
-      StickyResolveStrategy stickyResolveStrategy,
-      RetryStrategy retryStrategy) {
+      @Nonnull ApiSecret apiSecret,
+      @Nonnull String clientSecret,
+      @Nonnull StickyResolveStrategy stickyResolveStrategy,
+      @Nonnull RetryStrategy retryStrategy) {
     final var env = System.getenv("LOCAL_RESOLVE_MODE");
     if (env != null && env.equals("WASM")) {
       this.flagResolverService =
@@ -166,10 +167,10 @@ public class OpenFeatureLocalResolveProvider implements FeatureProvider {
    */
   @VisibleForTesting
   public OpenFeatureLocalResolveProvider(
-      AccountStateProvider accountStateProvider,
-      String accountId,
-      String clientSecret,
-      StickyResolveStrategy stickyResolveStrategy) {
+      @Nonnull AccountStateProvider accountStateProvider,
+      @Nonnull String accountId,
+      @Nonnull String clientSecret,
+      @Nonnull StickyResolveStrategy stickyResolveStrategy) {
     this(
         accountStateProvider,
         accountId,
@@ -191,11 +192,11 @@ public class OpenFeatureLocalResolveProvider implements FeatureProvider {
    */
   @VisibleForTesting
   public OpenFeatureLocalResolveProvider(
-      AccountStateProvider accountStateProvider,
-      String accountId,
-      String clientSecret,
-      StickyResolveStrategy stickyResolveStrategy,
-      RetryStrategy retryStrategy) {
+      @Nonnull AccountStateProvider accountStateProvider,
+      @Nonnull String accountId,
+      @Nonnull String clientSecret,
+      @Nonnull StickyResolveStrategy stickyResolveStrategy,
+      @Nonnull RetryStrategy retryStrategy) {
     this.stickyResolveStrategy = stickyResolveStrategy;
     this.clientSecret = clientSecret;
     this.flagResolverService =

--- a/openfeature-provider/pom.xml
+++ b/openfeature-provider/pom.xml
@@ -102,7 +102,12 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-    
+
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
+
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>

--- a/openfeature-provider/src/main/java/com/spotify/confidence/ConfidenceFeatureProvider.java
+++ b/openfeature-provider/src/main/java/com/spotify/confidence/ConfidenceFeatureProvider.java
@@ -62,7 +62,8 @@ public class ConfidenceFeatureProvider implements FeatureProvider {
    *     #ConfidenceFeatureProvider(Confidence.Builder)} instead.
    */
   @Deprecated()
-  public ConfidenceFeatureProvider(@Nonnull String clientSecret, @Nonnull ManagedChannel managedChannel) {
+  public ConfidenceFeatureProvider(
+      @Nonnull String clientSecret, @Nonnull ManagedChannel managedChannel) {
     this(Confidence.builder(clientSecret).flagResolverManagedChannel(managedChannel));
   }
 

--- a/openfeature-provider/src/main/java/com/spotify/confidence/ConfidenceFeatureProvider.java
+++ b/openfeature-provider/src/main/java/com/spotify/confidence/ConfidenceFeatureProvider.java
@@ -21,6 +21,7 @@ import io.grpc.StatusRuntimeException;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 import java.util.function.Function;
+import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 
 /** OpenFeature Provider for feature flagging with the Confidence platform */
@@ -33,7 +34,7 @@ public class ConfidenceFeatureProvider implements FeatureProvider {
    *
    * @param confidenceBuilder a Confidence.Builder
    */
-  public ConfidenceFeatureProvider(Confidence.Builder confidenceBuilder) {
+  public ConfidenceFeatureProvider(@Nonnull Confidence.Builder confidenceBuilder) {
     this.confidence = confidenceBuilder.buildForProvider();
   }
 
@@ -45,7 +46,7 @@ public class ConfidenceFeatureProvider implements FeatureProvider {
    *     #ConfidenceFeatureProvider(Confidence.Builder)} instead.
    */
   @Deprecated()
-  public ConfidenceFeatureProvider(Confidence confidence) {
+  public ConfidenceFeatureProvider(@Nonnull Confidence confidence) {
     this.confidence = confidence;
   }
 
@@ -61,7 +62,7 @@ public class ConfidenceFeatureProvider implements FeatureProvider {
    *     #ConfidenceFeatureProvider(Confidence.Builder)} instead.
    */
   @Deprecated()
-  public ConfidenceFeatureProvider(String clientSecret, ManagedChannel managedChannel) {
+  public ConfidenceFeatureProvider(@Nonnull String clientSecret, @Nonnull ManagedChannel managedChannel) {
     this(Confidence.builder(clientSecret).flagResolverManagedChannel(managedChannel));
   }
 
@@ -73,7 +74,7 @@ public class ConfidenceFeatureProvider implements FeatureProvider {
    *     #ConfidenceFeatureProvider(Confidence.Builder)} instead.
    */
   @Deprecated()
-  public ConfidenceFeatureProvider(String clientSecret) {
+  public ConfidenceFeatureProvider(@Nonnull String clientSecret) {
     this(clientSecret, ManagedChannelBuilder.forAddress("edge-grpc.spotify.com", 443).build());
   }
 
@@ -88,7 +89,7 @@ public class ConfidenceFeatureProvider implements FeatureProvider {
    *     #ConfidenceFeatureProvider(Confidence.Builder)} instead.
    */
   @Deprecated()
-  public ConfidenceFeatureProvider(String clientSecret, String host, int port) {
+  public ConfidenceFeatureProvider(@Nonnull String clientSecret, @Nonnull String host, int port) {
     this(clientSecret, ManagedChannelBuilder.forAddress(host, port).usePlaintext().build());
   }
 

--- a/sdk-java/src/main/java/com/spotify/confidence/Contextual.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/Contextual.java
@@ -1,8 +1,8 @@
 package com.spotify.confidence;
 
 import com.google.common.annotations.Beta;
-import javax.annotation.Nonnull;
 import java.util.Map;
+import javax.annotation.Nonnull;
 
 /**
  * Interface for managing contextual data in Confidence SDK. Provides methods to set, update, and

--- a/sdk-java/src/main/java/com/spotify/confidence/Contextual.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/Contextual.java
@@ -1,6 +1,7 @@
 package com.spotify.confidence;
 
 import com.google.common.annotations.Beta;
+import javax.annotation.Nonnull;
 import java.util.Map;
 
 /**
@@ -14,6 +15,7 @@ public interface Contextual {
    *
    * @return The current context as a {@link ConfidenceValue.Struct}
    */
+  @Nonnull
   ConfidenceValue.Struct getContext();
 
   /**
@@ -21,14 +23,14 @@ public interface Contextual {
    *
    * @param context The new context data to set
    */
-  void setContext(ConfidenceValue.Struct context);
+  void setContext(@Nonnull ConfidenceValue.Struct context);
 
   /**
    * Sets the context data using a Map of key-value pairs.
    *
    * @param context Map of context key-value pairs
    */
-  default void setContext(Map<String, ConfidenceValue> context) {
+  default void setContext(@Nonnull Map<String, ConfidenceValue> context) {
     setContext(ConfidenceValue.Struct.of(context));
   }
 
@@ -38,14 +40,14 @@ public interface Contextual {
    * @param key The key to update
    * @param value The new value for the key
    */
-  void updateContextEntry(String key, ConfidenceValue value);
+  void updateContextEntry(@Nonnull String key, @Nonnull ConfidenceValue value);
 
   /**
    * Removes a single entry from the context data.
    *
    * @param key The key to remove
    */
-  void removeContextEntry(String key);
+  void removeContextEntry(@Nonnull String key);
 
   /** Clears all context data. */
   void clearContext();
@@ -56,7 +58,8 @@ public interface Contextual {
    * @param context The new context to set
    * @return A new instance with the specified context
    */
-  Contextual withContext(ConfidenceValue.Struct context);
+  @Nonnull
+  Contextual withContext(@Nonnull ConfidenceValue.Struct context);
 
   /**
    * Creates a new instance with the specified context map.
@@ -64,7 +67,8 @@ public interface Contextual {
    * @param context Map of context key-value pairs
    * @return A new instance with the specified context
    */
-  default Contextual withContext(Map<String, ConfidenceValue> context) {
+  @Nonnull
+  default Contextual withContext(@Nonnull Map<String, ConfidenceValue> context) {
     return withContext(ConfidenceValue.Struct.of(context));
   }
 }

--- a/sdk-java/src/main/java/com/spotify/confidence/EventSender.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/EventSender.java
@@ -1,8 +1,8 @@
 package com.spotify.confidence;
 
 import com.google.common.annotations.Beta;
-import javax.annotation.Nonnull;
 import java.util.Map;
+import javax.annotation.Nonnull;
 
 /**
  * Interface for sending events to Confidence with context. Extends {@link Contextual} to provide

--- a/sdk-java/src/main/java/com/spotify/confidence/EventSender.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/EventSender.java
@@ -1,6 +1,7 @@
 package com.spotify.confidence;
 
 import com.google.common.annotations.Beta;
+import javax.annotation.Nonnull;
 import java.util.Map;
 
 /**
@@ -15,14 +16,14 @@ public interface EventSender extends Contextual {
    * @param eventName The name of the event to track
    * @param data The data associated with the event
    */
-  public void track(String eventName, ConfidenceValue.Struct data);
+  public void track(@Nonnull String eventName, @Nonnull ConfidenceValue.Struct data);
 
   /**
    * Tracks an event without associated data.
    *
    * @param eventName The name of the event to track
    */
-  public void track(String eventName);
+  public void track(@Nonnull String eventName);
 
   /** Flushes any pending events to ensure they are sent. */
   void flush();
@@ -33,8 +34,9 @@ public interface EventSender extends Contextual {
    * @param context The new context to set
    * @return A new instance with the specified context
    */
+  @Nonnull
   @Override
-  EventSender withContext(ConfidenceValue.Struct context);
+  EventSender withContext(@Nonnull ConfidenceValue.Struct context);
 
   /**
    * Creates a new instance with the specified context map.
@@ -42,8 +44,9 @@ public interface EventSender extends Contextual {
    * @param context Map of context key-value pairs
    * @return A new instance with the specified context
    */
+  @Nonnull
   @Override
-  default EventSender withContext(Map<String, ConfidenceValue> context) {
+  default EventSender withContext(@Nonnull Map<String, ConfidenceValue> context) {
     return withContext(ConfidenceValue.Struct.of(context));
   }
 }

--- a/sdk-java/src/main/java/com/spotify/confidence/FlagEvaluator.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/FlagEvaluator.java
@@ -1,5 +1,6 @@
 package com.spotify.confidence;
 
+import javax.annotation.Nonnull;
 import java.util.Map;
 
 /**
@@ -15,7 +16,8 @@ public interface FlagEvaluator extends Contextual {
    * @param <T> The type of the flag value
    * @return The evaluated flag value or the default value if evaluation fails
    */
-  <T> T getValue(String key, T defaultValue);
+  @Nonnull
+  <T> T getValue(@Nonnull String key, @Nonnull T defaultValue);
 
   /**
    * Gets a detailed evaluation of a feature flag for the current context.
@@ -25,7 +27,8 @@ public interface FlagEvaluator extends Contextual {
    * @param <T> The type of the flag value
    * @return A {@link FlagEvaluation} containing the evaluated value and evaluation details
    */
-  <T> FlagEvaluation<T> getEvaluation(String key, T defaultValue);
+  @Nonnull
+  <T> FlagEvaluation<T> getEvaluation(@Nonnull String key, @Nonnull T defaultValue);
 
   /**
    * Creates a new instance with the specified context.
@@ -33,8 +36,9 @@ public interface FlagEvaluator extends Contextual {
    * @param context The new context to set
    * @return A new instance with the specified context
    */
+  @Nonnull
   @Override
-  FlagEvaluator withContext(ConfidenceValue.Struct context);
+  FlagEvaluator withContext(@Nonnull ConfidenceValue.Struct context);
 
   /**
    * Creates a new instance with the specified context map.
@@ -42,8 +46,9 @@ public interface FlagEvaluator extends Contextual {
    * @param context Map of context key-value pairs
    * @return A new instance with the specified context
    */
+  @Nonnull
   @Override
-  default FlagEvaluator withContext(Map<String, ConfidenceValue> context) {
+  default FlagEvaluator withContext(@Nonnull Map<String, ConfidenceValue> context) {
     return withContext(ConfidenceValue.Struct.of(context));
   }
 }

--- a/sdk-java/src/main/java/com/spotify/confidence/FlagEvaluator.java
+++ b/sdk-java/src/main/java/com/spotify/confidence/FlagEvaluator.java
@@ -1,7 +1,7 @@
 package com.spotify.confidence;
 
-import javax.annotation.Nonnull;
 import java.util.Map;
+import javax.annotation.Nonnull;
 
 /**
  * Interface for evaluating feature flags with context. Extends {@link Contextual} to provide


### PR DESCRIPTION
## Summary
- Added `@Nonnull` annotations to public API interfaces (`Contextual`, `EventSender`, `FlagEvaluator`)
- Added `@Nonnull` annotations to public records and interfaces (`ApiSecret`, `AccountStateProvider`, `MaterializationRepository`, `MaterializationInfo`)
- Added `@Nonnull` annotations to provider constructors (`OpenFeatureLocalResolveProvider`, `ConfidenceFeatureProvider`)

This improves Kotlin interoperability by ensuring non-nullable types are properly recognized instead of being treated as platform types.

## Test plan
- [ ] Verify existing tests pass
- [ ] Test Kotlin consumer can properly recognize non-nullable types

🤖 Generated with [Claude Code](https://claude.com/claude-code)