### PR TITLE
ci: declare minimum permissions on workflow files

### DIFF
--- a/.github/workflows/ci-pull-request.yaml
+++ b/.github/workflows/ci-pull-request.yaml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Build/Test

--- a/.github/workflows/lint-pr-name.yaml
+++ b/.github/workflows/lint-pr-name.yaml
@@ -7,6 +7,10 @@ on:
       - edited
       - synchronize
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   main:
     name: Validate PR title


### PR DESCRIPTION
## Summary
- Adds explicit workflow-level `permissions:` blocks to harden `GITHUB_TOKEN` scope
- Standard CI workflows get `contents: read`
- Lint-pr workflows (running on `pull_request_target`) get `contents: read` + `pull-requests: write`
- Release workflows get `contents: write` + `pull-requests: write`

Motivated by CVE-2025-30066 — pinning permissions caps token authority if a third-party action is compromised.